### PR TITLE
Session Process Cleanup

### DIFF
--- a/nanome/_internal/_network/_session.py
+++ b/nanome/_internal/_network/_session.py
@@ -60,6 +60,7 @@ class _Session(object):
     def close_pipes(self):
         self.__net_plugin_pipe.close()
         self.__proc_plugin_pipe.close()
+        self._process_manager._remove_session_processes(self._session_id)
 
     def __init__(self, session_id, net_plugin, process_manager, logs_manager, net_pipe, proc_pipe):
         self._session_id = session_id

--- a/nanome/_internal/_process/_process_manager.py
+++ b/nanome/_internal/_process/_process_manager.py
@@ -128,6 +128,17 @@ class _ProcessManager():
                 entry.process.terminate()
                 break
 
+    def _remove_session_processes(self, session_id):
+        pending = [e for e in self.__pending if e.session._session_id == session_id]
+        running = [e for e in self.__running if e.session._session_id == session_id]
+
+        for entry in pending:
+            self.__pending.remove(entry)
+
+        for entry in running:
+            entry.process.kill()
+            self.__running.remove(entry)
+
     def _received_request(self, data, session):
         type = data[0]
         if type == _ProcessManager._CommandType.start:


### PR DESCRIPTION
When plugin session ends, all processes spawned by that session with the Process API should be killed and removed from pending