### PR TITLE
Add async/await support

### DIFF
--- a/nanome/_internal/_plugin_instance.py
+++ b/nanome/_internal/_plugin_instance.py
@@ -27,7 +27,7 @@ class _PluginInstance(object):
     @classmethod
     def _save_callback(cls, id, callback):
         if callback is None:
-            if asyncio and cls._is_async:
+            if asyncio and cls.is_async:
                 loop = asyncio.get_event_loop()
                 future = loop.create_future()
                 cls.__futures[id] = future
@@ -41,7 +41,7 @@ class _PluginInstance(object):
         callbacks = _PluginInstance.__callbacks
         futures = _PluginInstance.__futures
 
-        if asyncio and self._is_async and futures.get(id):
+        if asyncio and self.is_async and futures.get(id):
             futures[id].set_result(args)
             del futures[id]
             return
@@ -105,7 +105,7 @@ class _PluginInstance(object):
             return
 
     def _run(self):
-        if asyncio and self._is_async:
+        if asyncio and self.is_async:
             coro = _async_update_loop(self, UPDATE_RATE, MINIMUM_SLEEP)
             asyncio.run(coro)
         else:

--- a/nanome/_internal/_plugin_instance.py
+++ b/nanome/_internal/_plugin_instance.py
@@ -8,28 +8,45 @@ import traceback
 import time
 from timeit import default_timer as timer
 
+try:
+    import asyncio
+    from ._plugin_instance_async import _update
+except ImportError:
+    asyncio = False
+
 UPDATE_RATE = 1.0 / 60.0
 MINIMUM_SLEEP = 0.001
-HOOK_UNREF_CHECK_TIME = 30.0
 
 __metaclass__ = type
 class _PluginInstance(object):
     __callbacks = dict()
+    __futures = dict()
     __complex_updated_callbacks = dict()
     __selection_changed_callbacks = dict()
 
     @classmethod
     def _save_callback(cls, id, callback):
-        if callback == None:
-            cls.__callbacks[id] = lambda _=None: None
+        if callback is None:
+            if asyncio and cls._is_async:
+                loop = asyncio.get_event_loop()
+                future = loop.create_future()
+                cls.__futures[id] = future
+                return future
+            else:
+                cls.__callbacks[id] = lambda *_: None
         else:
             cls.__callbacks[id] = callback
 
     def _call(self, id, *args):
         callbacks = _PluginInstance.__callbacks
+        futures = _PluginInstance.__futures
         try:
-            callbacks[id](*args)
-            del callbacks[id]
+            if asyncio and self._is_async:
+                futures[id].set_result(args)
+                del futures[id]
+            else:
+                callbacks[id](*args)
+                del callbacks[id]
         except KeyError:
             Logs.warning('Received an unknown callback id:', id)
 
@@ -63,7 +80,7 @@ class _PluginInstance(object):
         except:
             Logs.error("Error in on_stop function:", traceback.format_exc())
 
-    def _run(self):
+    def _update(self):
         try:
             self.start()
             last_update = timer()
@@ -84,6 +101,13 @@ class _PluginInstance(object):
             self._process_manager._close()
             self._network._close()
             return
+
+    def _run(self):
+        if asyncio and self._is_async:
+            coro = _update(self, UPDATE_RATE, MINIMUM_SLEEP)
+            asyncio.run(coro)
+        else:
+            self._update()
 
     def __init__(self, session_id, net_pipe, proc_pipe, serializer, plugin_id, version_table, original_version_table, verbose, custom_data):
         Logs._set_verbose(verbose)

--- a/nanome/_internal/_plugin_instance.py
+++ b/nanome/_internal/_plugin_instance.py
@@ -40,13 +40,15 @@ class _PluginInstance(object):
     def _call(self, id, *args):
         callbacks = _PluginInstance.__callbacks
         futures = _PluginInstance.__futures
+
+        if asyncio and self._is_async and futures.get(id):
+            futures[id].set_result(args)
+            del futures[id]
+            return
+
         try:
-            if asyncio and self._is_async:
-                futures[id].set_result(args)
-                del futures[id]
-            else:
-                callbacks[id](*args)
-                del callbacks[id]
+            callbacks[id](*args)
+            del callbacks[id]
         except KeyError:
             Logs.warning('Received an unknown callback id:', id)
 

--- a/nanome/_internal/_plugin_instance.py
+++ b/nanome/_internal/_plugin_instance.py
@@ -10,7 +10,7 @@ from timeit import default_timer as timer
 
 try:
     import asyncio
-    from ._plugin_instance_async import _update
+    from ._plugin_instance_async import _async_update_loop
 except ImportError:
     asyncio = False
 
@@ -82,7 +82,7 @@ class _PluginInstance(object):
         except:
             Logs.error("Error in on_stop function:", traceback.format_exc())
 
-    def _update(self):
+    def _update_loop(self):
         try:
             self.start()
             last_update = timer()
@@ -106,7 +106,7 @@ class _PluginInstance(object):
 
     def _run(self):
         if asyncio and self._is_async:
-            coro = _update(self, UPDATE_RATE, MINIMUM_SLEEP)
+            coro = _async_update_loop(self, UPDATE_RATE, MINIMUM_SLEEP)
             asyncio.run(coro)
         else:
             self._update()

--- a/nanome/_internal/_plugin_instance_async.py
+++ b/nanome/_internal/_plugin_instance_async.py
@@ -4,7 +4,7 @@ import asyncio
 import traceback
 from timeit import default_timer as timer
 
-async def _update(self, UPDATE_RATE, MINIMUM_SLEEP):
+async def _async_update_loop(self, UPDATE_RATE, MINIMUM_SLEEP):
     try:
         self.start()
         last_update = timer()

--- a/nanome/_internal/_plugin_instance_async.py
+++ b/nanome/_internal/_plugin_instance_async.py
@@ -1,0 +1,27 @@
+from nanome.util import Logs
+
+import asyncio
+import traceback
+from timeit import default_timer as timer
+
+async def _update(self, UPDATE_RATE, MINIMUM_SLEEP):
+    try:
+        self.start()
+        last_update = timer()
+        while self._network._receive() and self._process_manager.update():
+            self.update()
+
+            dt = last_update - timer()
+            sleep_time = max(UPDATE_RATE - dt, MINIMUM_SLEEP)
+            await asyncio.sleep(sleep_time)
+            last_update = timer()
+
+    except KeyboardInterrupt:
+        self._on_stop()
+        return
+    except:
+        Logs.error(traceback.format_exc())
+        self._on_stop()
+        self._process_manager._close()
+        self._network._close()
+        return

--- a/nanome/api/__init__.py
+++ b/nanome/api/__init__.py
@@ -1,7 +1,7 @@
 from . import *
 from .room import Room
 from .files import Files
-from .plugin_instance import PluginInstance, _DefaultPlugin
+from .plugin_instance import AsyncPluginInstance, PluginInstance, _DefaultPlugin
 from .plugin import Plugin
 from . import streams
 from . import ui

--- a/nanome/api/plugin_instance.py
+++ b/nanome/api/plugin_instance.py
@@ -11,6 +11,7 @@ from nanome.api import Room, Files
 import os
 
 class PluginInstance(_PluginInstance):
+    _is_async = False
 
     """
     | Base class of any Plugin class.
@@ -94,21 +95,21 @@ class PluginInstance(_PluginInstance):
         """
         pass
 
-    def request_workspace(self, callback = None):
+    def request_workspace(self, callback=None):
         """
         | Request the entire workspace, in deep mode
         """
-        id = self._network._send(_Messages.workspace_request, None, callback != None)
-        self._save_callback(id, callback)
+        id = self._network._send(_Messages.workspace_request, None, callback != None or self._is_async)
+        return self._save_callback(id, callback)
 
-    def request_complex_list(self, callback = None):
+    def request_complex_list(self, callback=None):
         """
         | Request the list of all complexes in the workspace, in shallow mode
         """
-        id = self._network._send(_Messages.complex_list_request, None, callback != None)
-        self._save_callback(id, callback)
+        id = self._network._send(_Messages.complex_list_request, None, callback != None or self._is_async)
+        return self._save_callback(id, callback)
 
-    def request_complexes(self, id_list, callback = None):
+    def request_complexes(self, id_list, callback=None):
         """
         | Requests a list of complexes by their indices
         | Complexes returned contains the full structure (atom/bond/residue/chain/molecule)
@@ -116,8 +117,8 @@ class PluginInstance(_PluginInstance):
         :param id_list: List of indices
         :type id_list: list of :class:`int`
         """
-        id = self._network._send(_Messages.complexes_request, id_list, callback != None)
-        self._save_callback(id, callback)
+        id = self._network._send(_Messages.complexes_request, id_list, callback != None or self._is_async)
+        return self._save_callback(id, callback)
 
     def update_workspace(self, workspace):
         """
@@ -142,7 +143,7 @@ class PluginInstance(_PluginInstance):
         args = (type, message)
         self._network._send(_Messages.notification_send, args, False)
 
-    def update_structures_deep(self, structures, callback = None):
+    def update_structures_deep(self, structures, callback=None):
         """
         | Update the specific molecular structures in the scene to match the structures in parameter.
         | Will also update descendent structures and can be used to remove descendent structures.
@@ -150,8 +151,8 @@ class PluginInstance(_PluginInstance):
         :param structures: List of molecular structures to update.
         :type structures: list of :class:`~nanome.api.structure.base.Base`
         """
-        id = self._network._send(_Messages.structures_deep_update, structures, callback != None)
-        self._save_callback(id, callback)
+        id = self._network._send(_Messages.structures_deep_update, structures, callback != None or self._is_async)
+        return self._save_callback(id, callback)
 
     def update_structures_shallow(self, structures):
         """
@@ -171,8 +172,8 @@ class PluginInstance(_PluginInstance):
         :param structures: Molecular structure(s) to update.
         :type structures: list of :class:`~nanome.api.structure.base.Base`
         """
-        id = self._network._send(_Messages.structures_zoom, structures, callback != None)
-        self._save_callback(id, callback)
+        id = self._network._send(_Messages.structures_zoom, structures, callback != None or self._is_async)
+        return self._save_callback(id, callback)
 
     def center_on_structures(self, structures, callback=None):
         """
@@ -182,8 +183,8 @@ class PluginInstance(_PluginInstance):
         :param structures: Molecular structure(s) to update.
         :type structures: list of :class:`~nanome.api.structure.base.Base`
         """
-        id = self._network._send(_Messages.structures_center, structures, callback != None)
-        self._save_callback(id, callback)
+        id = self._network._send(_Messages.structures_center, structures, callback != None or self._is_async)
+        return self._save_callback(id, callback)
 
     def add_to_workspace(self, complex_list, callback=None):
         """
@@ -192,8 +193,8 @@ class PluginInstance(_PluginInstance):
         :param complex_list: List of Complexes to add
         :type complex_list: list of :class:`~nanome.api.structure.complex.Complex`
         """
-        id = self._network._send(_Messages.add_to_workspace, complex_list, callback != None)
-        self._save_callback(id, callback)
+        id = self._network._send(_Messages.add_to_workspace, complex_list, callback != None or self._is_async)
+        return self._save_callback(id, callback)
 
     def update_menu(self, menu):
         """
@@ -247,25 +248,25 @@ class PluginInstance(_PluginInstance):
         self._network._send(_Messages.menu_transform_set,
                             (index, position, rotation, scale), False)
 
-    def request_menu_transform(self, index, callback):
+    def request_menu_transform(self, index, callback=None):
         """
         | Requests spacial information of the plugin menu (position, rotation, scale)
 
         :param index: Index of the menu you wish to read
         :type index: int
         """
-        id = self._network._send(_Messages.menu_transform_request, index, callback != None)
-        self._save_callback(id, callback)
+        id = self._network._send(_Messages.menu_transform_request, index, callback != None or self._is_async)
+        return self._save_callback(id, callback)
 
-    def save_files(self, file_list, callback = None):
+    def save_files(self, file_list, callback=None):
         """
         | Save files on the machine running Nanome, and returns result
 
         :param file_list: List of files to save with their content
         :type file_list: list of :class:`~nanome.util.file.FileSaveData`
         """
-        id = self._network._send(_Messages.file_save, file_list, callback != None)
-        self._save_callback(id, callback)
+        id = self._network._send(_Messages.file_save, file_list, callback != None or self._is_async)
+        return self._save_callback(id, callback)
 
     @Logs.deprecated("create_writing_stream")
     def create_stream(self, atom_indices_list, callback):
@@ -276,7 +277,7 @@ class PluginInstance(_PluginInstance):
     def create_atom_stream(self, atom_indices_list, stream_type, callback):
         self.create_writing_stream(atom_indices_list, stream_type, callback)
 
-    def create_writing_stream(self, indices_list, stream_type, callback):
+    def create_writing_stream(self, indices_list, stream_type, callback=None):
         """
         | Create a stream allowing to continuously update properties of many objects
 
@@ -285,10 +286,10 @@ class PluginInstance(_PluginInstance):
         :param stream_type: Type of stream to create
         :type stream_type: list of :class:`~nanome.api.stream.Stream.Type`
         """
-        id = self._network._send(_Messages.stream_create, (stream_type, indices_list, StreamDirection.writing), callback != None)
-        self._save_callback(id, callback)
+        id = self._network._send(_Messages.stream_create, (stream_type, indices_list, StreamDirection.writing), callback != None or self._is_async)
+        return self._save_callback(id, callback)
 
-    def create_reading_stream(self, indices_list, stream_type, callback):
+    def create_reading_stream(self, indices_list, stream_type, callback=None):
         """
         | Create a stream allowing to continuously receive properties of many objects
 
@@ -297,8 +298,8 @@ class PluginInstance(_PluginInstance):
         :param stream_type: Type of stream to create
         :type stream_type: list of :class:`~nanome.api.stream.Stream.Type`
         """
-        id = self._network._send(_Messages.stream_create, (stream_type, indices_list, StreamDirection.reading), callback != None)
-        self._save_callback(id, callback)
+        id = self._network._send(_Messages.stream_create, (stream_type, indices_list, StreamDirection.reading), callback != None or self._is_async)
+        return self._save_callback(id, callback)
 
     def add_bonds(self, complex_list, callback, fast_mode=None):
         """
@@ -321,9 +322,9 @@ class PluginInstance(_PluginInstance):
         dssp = _Dssp(complex_list, callback)
         dssp._start()
 
-    def add_volume(self, complex, volume, properties, complex_to_align_index = -1, callback = None):
-        id = self._network._send(_Messages.add_volume, (complex, complex_to_align_index, volume, properties), callback != None)
-        self._save_callback(id, callback)
+    def add_volume(self, complex, volume, properties, complex_to_align_index=-1, callback=None):
+        id = self._network._send(_Messages.add_volume, (complex, complex_to_align_index, volume, properties), callback != None or self._is_async)
+        return self._save_callback(id, callback)
 
     def open_url(self, url):
         """
@@ -337,19 +338,19 @@ class PluginInstance(_PluginInstance):
             url = 'http://' + url
         self._network._send(_Messages.open_url, url, False)
 
-    def request_presenter_info(self, callback):
+    def request_presenter_info(self, callback=None):
         """
         | Requests presenter account info (unique ID, name, email)
         """
-        id = self._network._send(_Messages.presenter_info_request, None, callback != None)
-        self._save_callback(id, callback)
+        id = self._network._send(_Messages.presenter_info_request, None, callback != None or self._is_async)
+        return self._save_callback(id, callback)
 
-    def request_controller_transforms(self, callback):
+    def request_controller_transforms(self, callback=None):
         """
         | Requests presenter controller info (head position, head rotation, left controller position, left controller rotation, right controller position, right controller rotation)
         """
-        id = self._network._send(_Messages.controller_transforms_request, None, callback != None)
-        self._save_callback(id, callback)
+        id = self._network._send(_Messages.controller_transforms_request, None, callback != None or self._is_async)
+        return self._save_callback(id, callback)
 
     def set_plugin_list_button(self, button, text = None, usable = None):
         """
@@ -402,10 +403,10 @@ class PluginInstance(_PluginInstance):
                 data = content_file.read()
             files.append((file_name, data))
 
-        id = self._network._send(_Messages.load_file, (files, True, True), callback != None)
-        self._save_callback(id, callback)
+        id = self._network._send(_Messages.load_file, (files, True, True), callback != None or self._is_async)
+        return self._save_callback(id, callback)
 
-    def request_export(self, format, callback, entities = None):
+    def request_export(self, format, callback=None, entities=None):
         """
         Request a file export using Nanome exporters
         Can request either molecule or workspace export, for entities in Nanome workspace
@@ -420,7 +421,7 @@ class PluginInstance(_PluginInstance):
             entities = [entities]
 
         id = self._network._send(_Messages.export_files, (format, entities), True)
-        self._save_callback(id, callback)
+        return self._save_callback(id, callback)
 
     def apply_color_scheme(self, color_scheme, target, only_carbons):
         """
@@ -450,6 +451,9 @@ class PluginInstance(_PluginInstance):
         :type: tuple of objects or None if no data has been set
         """
         return self._custom_data
+
+class AsyncPluginInstance(PluginInstance):
+    _is_async = True
 
 class _DefaultPlugin(PluginInstance):
     def __init__(self):

--- a/nanome/api/plugin_instance.py
+++ b/nanome/api/plugin_instance.py
@@ -11,7 +11,7 @@ from nanome.api import Room, Files
 import os
 
 class PluginInstance(_PluginInstance):
-    _is_async = False
+    is_async = False
 
     """
     | Base class of any Plugin class.
@@ -99,14 +99,14 @@ class PluginInstance(_PluginInstance):
         """
         | Request the entire workspace, in deep mode
         """
-        id = self._network._send(_Messages.workspace_request, None, callback != None or self._is_async)
+        id = self._network._send(_Messages.workspace_request, None, callback != None or self.is_async)
         return self._save_callback(id, callback)
 
     def request_complex_list(self, callback=None):
         """
         | Request the list of all complexes in the workspace, in shallow mode
         """
-        id = self._network._send(_Messages.complex_list_request, None, callback != None or self._is_async)
+        id = self._network._send(_Messages.complex_list_request, None, callback != None or self.is_async)
         return self._save_callback(id, callback)
 
     def request_complexes(self, id_list, callback=None):
@@ -117,7 +117,7 @@ class PluginInstance(_PluginInstance):
         :param id_list: List of indices
         :type id_list: list of :class:`int`
         """
-        id = self._network._send(_Messages.complexes_request, id_list, callback != None or self._is_async)
+        id = self._network._send(_Messages.complexes_request, id_list, callback != None or self.is_async)
         return self._save_callback(id, callback)
 
     def update_workspace(self, workspace):
@@ -151,7 +151,7 @@ class PluginInstance(_PluginInstance):
         :param structures: List of molecular structures to update.
         :type structures: list of :class:`~nanome.api.structure.base.Base`
         """
-        id = self._network._send(_Messages.structures_deep_update, structures, callback != None or self._is_async)
+        id = self._network._send(_Messages.structures_deep_update, structures, callback != None or self.is_async)
         return self._save_callback(id, callback)
 
     def update_structures_shallow(self, structures):
@@ -172,7 +172,7 @@ class PluginInstance(_PluginInstance):
         :param structures: Molecular structure(s) to update.
         :type structures: list of :class:`~nanome.api.structure.base.Base`
         """
-        id = self._network._send(_Messages.structures_zoom, structures, callback != None or self._is_async)
+        id = self._network._send(_Messages.structures_zoom, structures, callback != None or self.is_async)
         return self._save_callback(id, callback)
 
     def center_on_structures(self, structures, callback=None):
@@ -183,7 +183,7 @@ class PluginInstance(_PluginInstance):
         :param structures: Molecular structure(s) to update.
         :type structures: list of :class:`~nanome.api.structure.base.Base`
         """
-        id = self._network._send(_Messages.structures_center, structures, callback != None or self._is_async)
+        id = self._network._send(_Messages.structures_center, structures, callback != None or self.is_async)
         return self._save_callback(id, callback)
 
     def add_to_workspace(self, complex_list, callback=None):
@@ -193,7 +193,7 @@ class PluginInstance(_PluginInstance):
         :param complex_list: List of Complexes to add
         :type complex_list: list of :class:`~nanome.api.structure.complex.Complex`
         """
-        id = self._network._send(_Messages.add_to_workspace, complex_list, callback != None or self._is_async)
+        id = self._network._send(_Messages.add_to_workspace, complex_list, callback != None or self.is_async)
         return self._save_callback(id, callback)
 
     def update_menu(self, menu):
@@ -255,7 +255,7 @@ class PluginInstance(_PluginInstance):
         :param index: Index of the menu you wish to read
         :type index: int
         """
-        id = self._network._send(_Messages.menu_transform_request, index, callback != None or self._is_async)
+        id = self._network._send(_Messages.menu_transform_request, index, callback != None or self.is_async)
         return self._save_callback(id, callback)
 
     def save_files(self, file_list, callback=None):
@@ -265,7 +265,7 @@ class PluginInstance(_PluginInstance):
         :param file_list: List of files to save with their content
         :type file_list: list of :class:`~nanome.util.file.FileSaveData`
         """
-        id = self._network._send(_Messages.file_save, file_list, callback != None or self._is_async)
+        id = self._network._send(_Messages.file_save, file_list, callback != None or self.is_async)
         return self._save_callback(id, callback)
 
     @Logs.deprecated("create_writing_stream")
@@ -286,7 +286,7 @@ class PluginInstance(_PluginInstance):
         :param stream_type: Type of stream to create
         :type stream_type: list of :class:`~nanome.api.stream.Stream.Type`
         """
-        id = self._network._send(_Messages.stream_create, (stream_type, indices_list, StreamDirection.writing), callback != None or self._is_async)
+        id = self._network._send(_Messages.stream_create, (stream_type, indices_list, StreamDirection.writing), callback != None or self.is_async)
         return self._save_callback(id, callback)
 
     def create_reading_stream(self, indices_list, stream_type, callback=None):
@@ -298,7 +298,7 @@ class PluginInstance(_PluginInstance):
         :param stream_type: Type of stream to create
         :type stream_type: list of :class:`~nanome.api.stream.Stream.Type`
         """
-        id = self._network._send(_Messages.stream_create, (stream_type, indices_list, StreamDirection.reading), callback != None or self._is_async)
+        id = self._network._send(_Messages.stream_create, (stream_type, indices_list, StreamDirection.reading), callback != None or self.is_async)
         return self._save_callback(id, callback)
 
     def add_bonds(self, complex_list, callback, fast_mode=None):
@@ -323,7 +323,7 @@ class PluginInstance(_PluginInstance):
         dssp._start()
 
     def add_volume(self, complex, volume, properties, complex_to_align_index=-1, callback=None):
-        id = self._network._send(_Messages.add_volume, (complex, complex_to_align_index, volume, properties), callback != None or self._is_async)
+        id = self._network._send(_Messages.add_volume, (complex, complex_to_align_index, volume, properties), callback != None or self.is_async)
         return self._save_callback(id, callback)
 
     def open_url(self, url):
@@ -342,14 +342,14 @@ class PluginInstance(_PluginInstance):
         """
         | Requests presenter account info (unique ID, name, email)
         """
-        id = self._network._send(_Messages.presenter_info_request, None, callback != None or self._is_async)
+        id = self._network._send(_Messages.presenter_info_request, None, callback != None or self.is_async)
         return self._save_callback(id, callback)
 
     def request_controller_transforms(self, callback=None):
         """
         | Requests presenter controller info (head position, head rotation, left controller position, left controller rotation, right controller position, right controller rotation)
         """
-        id = self._network._send(_Messages.controller_transforms_request, None, callback != None or self._is_async)
+        id = self._network._send(_Messages.controller_transforms_request, None, callback != None or self.is_async)
         return self._save_callback(id, callback)
 
     def set_plugin_list_button(self, button, text = None, usable = None):
@@ -403,7 +403,7 @@ class PluginInstance(_PluginInstance):
                 data = content_file.read()
             files.append((file_name, data))
 
-        id = self._network._send(_Messages.load_file, (files, True, True), callback != None or self._is_async)
+        id = self._network._send(_Messages.load_file, (files, True, True), callback != None or self.is_async)
         return self._save_callback(id, callback)
 
     def request_export(self, format, callback=None, entities=None):
@@ -453,7 +453,7 @@ class PluginInstance(_PluginInstance):
         return self._custom_data
 
 class AsyncPluginInstance(PluginInstance):
-    _is_async = True
+    is_async = True
 
 class _DefaultPlugin(PluginInstance):
     def __init__(self):

--- a/nanome/util/__init__.py
+++ b/nanome/util/__init__.py
@@ -9,6 +9,11 @@ try:
 except:
     pass
 
+try:
+    from .asyncio import async_callback
+except:
+    pass
+
 from . import enums
 from . import complex_save_options
 

--- a/nanome/util/asyncio.py
+++ b/nanome/util/asyncio.py
@@ -1,0 +1,7 @@
+import asyncio
+
+def async_callback(fn):
+    def task(*args, **kwargs):
+        loop = asyncio.get_running_loop()
+        return loop.create_task(fn(*args, **kwargs))
+    return task

--- a/test_plugins/AsyncTest.py
+++ b/test_plugins/AsyncTest.py
@@ -1,0 +1,25 @@
+import nanome
+from nanome.util import async_callback, Logs
+
+NAME = "Async Test"
+DESCRIPTION = "Tests async/await in plugins."
+CATEGORY = "testing"
+HAS_ADVANCED_OPTIONS = False
+
+class AsyncTest(nanome.AsyncPluginInstance):
+    def start(self):
+        self.on_run()
+
+    @async_callback
+    async def on_run(self):
+        shallow, = await self.request_complex_list()
+        index = shallow[0].index
+
+        deep, = await self.request_complexes([index])
+        complex = deep[0]
+        complex.position.x += 1
+
+        await self.update_structures_deep([complex])
+        Logs.message('done')
+
+nanome.Plugin.setup(NAME, DESCRIPTION, CATEGORY, False, AsyncTest)


### PR DESCRIPTION
This PR adds the long awaited (heh) `async`/`await` support to plugins.

Notes:
- Plugin must inherit from `AsyncPluginInstance`, or manually set `_is_async = True` on the class
- Any `async` functions in a plugin must be decorated with `nanome.util.async_callback` in order to properly get executed in the asyncio event loop
- Example plugin at `test_plugins/AsyncTest.py`
- `python2` friendly - no `async`/`await` in `python2`, so measures taken to not break the whole lib
- Return values of awaitables are lists of values, for instance `request_complex_list` is `[[shallow_complex, shallow_complex, ...]]` and `request_menu_transform` is `[position, rotation, scale]`, so in the example plugin, the `shallow, = await ...` is grabbing the first item, which is the shallow complex list

TODO:
- `add_bonds`/`add_dssp` not awaitable yet