### PR TITLE
Fix atom save constraints with convert_to_frames

### DIFF
--- a/nanome/_internal/_plugin_instance.py
+++ b/nanome/_internal/_plugin_instance.py
@@ -47,11 +47,12 @@ class _PluginInstance(object):
             del futures[id]
             return
 
-        try:
-            callbacks[id](*args)
-            del callbacks[id]
-        except KeyError:
+        if id not in callbacks:
             Logs.warning('Received an unknown callback id:', id)
+            return
+
+        callbacks[id](*args)
+        del callbacks[id]
 
     @classmethod
     def _hook_complex_updated(cls, index, callback):

--- a/nanome/_internal/_structure/_complex.py
+++ b/nanome/_internal/_structure/_complex.py
@@ -106,8 +106,8 @@ class _Complex(_Base):
         result = _helpers._conformer_helper.convert_to_conformers(self, None)
         return result
 
-    def _convert_to_frames(self):
-        result = _helpers._conformer_helper.convert_to_frames(self)
+    def _convert_to_frames(self, old_to_new_atoms = None):
+        result = _helpers._conformer_helper.convert_to_frames(self, old_to_new_atoms)
         return result
 
     def __copy_received_complex(self, new_complex):

--- a/nanome/_internal/_structure/_helpers/_conformer_helper.py
+++ b/nanome/_internal/_structure/_helpers/_conformer_helper.py
@@ -6,12 +6,12 @@ s_ConformersAlways = False #Nanome.Core.Config.getBool("mol-conformers-always", 
 def _get_hash_code(string):
     return hash(string)
 
-def convert_to_frames(complex): #Data.Complex -> Data.Complex
+def convert_to_frames(complex, old_to_new_atoms = None): #Data.Complex -> Data.Complex
     new_complex = complex._shallow_copy()
     for molecule in complex._molecules:
         count = molecule._conformer_count
         for i in range(count):
-            new_complex.add_molecule(molecule._deep_copy(i))
+            new_complex.add_molecule(molecule._deep_copy(i, old_to_new_atoms))
     return new_complex
 
 def convert_to_conformers(complex, force_conformer = None): #Data.Complex -> Data.Complex

--- a/nanome/_internal/_structure/_helpers/_copy.py
+++ b/nanome/_internal/_structure/_helpers/_copy.py
@@ -1,8 +1,8 @@
 def _deep_copy_complex(complex):
     return __deep_copy_complex(complex, {})
 
-def _deep_copy_molecule(molecule, conformer_number = None):
-    return __deep_copy_molecule(molecule, {}, conformer_number)
+def _deep_copy_molecule(molecule, conformer_number = None, old_to_new_atoms = None):
+    return __deep_copy_molecule(molecule, {}, conformer_number, old_to_new_atoms)
 
 def _deep_copy_chain(chain, conformer_number = None):
     return __deep_copy_chain(chain, {}, conformer_number)
@@ -20,10 +20,10 @@ def __deep_copy_complex(complex, bond_set):
     new_complex._set_molecules(new_molecules)
     return new_complex
 
-def __deep_copy_molecule(molecule, bond_set, conformer_number):
+def __deep_copy_molecule(molecule, bond_set, conformer_number, old_to_new_atoms = None):
     new_chains = None
     for chain in molecule._chains:
-        new_chain = __deep_copy_chain(chain, bond_set, conformer_number)
+        new_chain = __deep_copy_chain(chain, bond_set, conformer_number, old_to_new_atoms)
         if new_chain != None:
             new_chains = __list_with(new_chains, new_chain)
     if new_chains != None:
@@ -32,10 +32,10 @@ def __deep_copy_molecule(molecule, bond_set, conformer_number):
         return new_molecule
     return molecule._shallow_copy(conformer_number)
 
-def __deep_copy_chain(chain, bond_set, conformer_number):
+def __deep_copy_chain(chain, bond_set, conformer_number, old_to_new_atoms = None):
     new_residues = None
     for residue in chain._residues:
-        new_residue = __deep_copy_residue(residue, bond_set, conformer_number)
+        new_residue = __deep_copy_residue(residue, bond_set, conformer_number, old_to_new_atoms)
         if new_residue != None:
             new_residues = __list_with(new_residues, new_residue)
     if new_residues != None:
@@ -46,7 +46,7 @@ def __deep_copy_chain(chain, bond_set, conformer_number):
         return chain._shallow_copy(conformer_number)
     return None
 
-def __deep_copy_residue(residue, bond_set, conformer_number):
+def __deep_copy_residue(residue, bond_set, conformer_number, old_to_new_atoms = None):
     new_bonds = None
     new_atoms = None
     for bond in residue._bonds:
@@ -57,6 +57,8 @@ def __deep_copy_residue(residue, bond_set, conformer_number):
         if conformer_number is None or atom._in_conformer[conformer_number]:
             new_atom = atom._shallow_copy(conformer_number)
             new_atoms = __list_with(new_atoms, new_atom)
+            if old_to_new_atoms is not None:
+                old_to_new_atoms[atom] = new_atom
         for bond in atom._bonds:
             if conformer_number is None or bond._in_conformer[conformer_number]:
                 new_bond = __no_dup_copy_bond(bond, bond_set, conformer_number)

--- a/nanome/_internal/_structure/_io/_pdb/save.py
+++ b/nanome/_internal/_structure/_io/_pdb/save.py
@@ -21,10 +21,22 @@ Options = nanome.util.complex_save_options.PDBSaveOptions
 
 def to_file(path, complex, options = None):
     # type: (str, _Complex, Options) -> Results
-    complex = complex._convert_to_frames()
     result = Results()
     if options is None:
         options = Options()
+
+    saved_atom_constraint = options.only_save_these_atoms
+    old_to_new_atom = None
+    if saved_atom_constraint is not None:
+        old_to_new_atom = {}
+    complex = complex._convert_to_frames(old_to_new_atom)
+    if saved_atom_constraint is not None:
+        new_constraint = []
+        for atom in saved_atom_constraint:
+            if atom in old_to_new_atom:
+                new_constraint.append(old_to_new_atom[atom])
+        saved_atom_constraint = new_constraint
+
     serial_by_atom =  {} #<Atom, int>
     lines =  []
     line = pad_right(10, "NUMMDL")
@@ -40,7 +52,6 @@ def to_file(path, complex, options = None):
             return None
         for chain in chains:
             for residue in chain._residues:
-                saved_atom_constraint = options.only_save_these_atoms
                 for atom in residue._atoms:
                     if saved_atom_constraint is None or atom in saved_atom_constraint:
                         if options.write_het_atoms or atom.is_het is False:

--- a/nanome/_internal/_structure/_molecule.py
+++ b/nanome/_internal/_structure/_molecule.py
@@ -154,5 +154,5 @@ class _Molecule(_Base):
             molecule._current_conformer = 0
         return molecule
 
-    def _deep_copy(self, conformer_number = None):
-        return _helpers._copy._deep_copy_molecule(self, conformer_number)
+    def _deep_copy(self, conformer_number = None, old_to_new_atoms = None):
+        return _helpers._copy._deep_copy_molecule(self, conformer_number, old_to_new_atoms)


### PR DESCRIPTION
Needs to be tested by @nezix, I haven't tested it!
This fixes atom save constraints, that was broken by convert_to_frames (atom references weren't matching anymore). I couldn't find another solution that would have worked in 100% of cases