### PR TITLE
added in the display_mode int flag.

### DIFF
--- a/nanome/_internal/_structure/_atom.py
+++ b/nanome/_internal/_structure/_atom.py
@@ -32,13 +32,13 @@ class _Atom(_Base):
         self._atom_mode = _Atom.AtomRenderingMode.BallStick
         self._labeled = False
         self._label_text = ""
-        self._atom_rendering = True
         self._atom_color = Color.Clear()
         self._atom_scale = 0.5
         self._surface_rendering = False
         self._surface_color = Color.Clear()
         self._surface_opacity = 1.0
         #No API
+        self._display_mode = 0xFFFFFFFF
         self._hydrogened = True
         self._watered = True
         self._het_atomed = True
@@ -52,6 +52,17 @@ class _Atom(_Base):
         self._parent = None
         _Atom._atom_count += 1
     
+    @property
+    def _atom_rendering(self):
+        return self._display_mode | 1
+
+    @_atom_rendering.setter
+    def _atom_rendering(self, value):
+        if value:
+            self._display_mode |= 1
+        else:
+            self._display_mode &= 0xFFFFFFFE
+
     #region connections
     @property
     def _residue(self):
@@ -165,13 +176,13 @@ class _Atom(_Base):
         atom._atom_mode = self._atom_mode
         atom._labeled = self._labeled
         atom._label_text = self._label_text
-        atom._atom_rendering = self._atom_rendering
         atom._atom_color = self._atom_color.copy()
         atom._atom_scale = self._atom_scale
         atom._surface_rendering = self._surface_rendering
         atom._surface_color = self._surface_color.copy()
         atom._surface_opacity = self._surface_opacity
         #No API
+        self._display_mode = self._display_mode
         atom._hydrogened = self._hydrogened
         atom._watered = self._watered
         atom._het_atomed = self._het_atomed

--- a/nanome/_internal/_structure/_atom.py
+++ b/nanome/_internal/_structure/_atom.py
@@ -54,7 +54,7 @@ class _Atom(_Base):
     
     @property
     def _atom_rendering(self):
-        return self._display_mode | 1
+        return self._display_mode & 1
 
     @_atom_rendering.setter
     def _atom_rendering(self, value):

--- a/nanome/_internal/_structure/_atom.py
+++ b/nanome/_internal/_structure/_atom.py
@@ -182,7 +182,7 @@ class _Atom(_Base):
         atom._surface_color = self._surface_color.copy()
         atom._surface_opacity = self._surface_opacity
         #No API
-        self._display_mode = self._display_mode
+        atom._display_mode = self._display_mode
         atom._hydrogened = self._hydrogened
         atom._watered = self._watered
         atom._het_atomed = self._het_atomed

--- a/nanome/_internal/_structure/_serialization/_atom_serializer.py
+++ b/nanome/_internal/_structure/_serialization/_atom_serializer.py
@@ -22,7 +22,8 @@ class _AtomSerializer(_TypeSerializer):
         # Version 4 corresponds to Nanome release 1.16
         # Version 5 corresponds to Nanome release 1.19
         # Version 6 corresponds to Nanome release 1.22
-        return 6
+        # Version 7 corresponds to Nanome release 1.22
+        return 7
 
     def name(self):
         return "Atom"
@@ -34,7 +35,8 @@ class _AtomSerializer(_TypeSerializer):
         context.write_bool(value._labeled)
         if version >= 1:
             context.write_using_serializer(self.string, value._label_text)
-        context.write_bool(value._atom_rendering)
+        if version <= 6:
+            context.write_bool(value._atom_rendering)
         context.write_using_serializer(self.color, value._atom_color)
         if version >= 2:
             context.write_float(value._atom_scale)
@@ -42,9 +44,10 @@ class _AtomSerializer(_TypeSerializer):
         context.write_using_serializer(self.color, value._surface_color)
         context.write_float(value._surface_opacity)
 
-        context.write_bool(value._hydrogened)
-        context.write_bool(value._watered)
-        context.write_bool(value._het_atomed)
+        if version <= 6:
+            context.write_bool(value._hydrogened)
+            context.write_bool(value._watered)
+            context.write_bool(value._het_atomed)
         context.write_bool(value._het_surfaced)
         context.write_using_serializer(self.string, value._symbol)
         context.write_int(value._serial)
@@ -85,6 +88,9 @@ class _AtomSerializer(_TypeSerializer):
             context.write_float(value._partial_charge)
             context.write_using_serializer(self.dict, value._atom_type)
 
+        if version >= 7:
+            context.WriteInt(value._display_mode)
+
     def deserialize(self, version, context):
         # type: (_Atom, _ContextDeserialization) -> _Atom
         atom = _Atom._create()
@@ -96,7 +102,8 @@ class _AtomSerializer(_TypeSerializer):
         atom._labeled = context.read_bool()
         if version >= 1:
             atom._label_text = context.read_using_serializer(self.string)
-        atom._atom_rendering = context.read_bool()
+        if version <= 6:
+            atom._atom_rendering = context.read_bool()
         atom._atom_color = context.read_using_serializer(self.color)
         if version >= 2:
             atom._atom_scale = context.read_float()
@@ -104,9 +111,10 @@ class _AtomSerializer(_TypeSerializer):
         atom._surface_color = context.read_using_serializer(self.color)
         atom._surface_opacity = context.read_float()
 
-        atom._hydrogened = context.read_bool()
-        atom._watered = context.read_bool()
-        atom._het_atomed = context.read_bool()
+        if version <= 6:
+            atom._hydrogened = context.read_bool()
+            atom._watered = context.read_bool()
+            atom._het_atomed = context.read_bool()
         atom._het_surfaced = context.read_bool()
 
         atom._symbol = context.read_using_serializer(self.string)
@@ -143,5 +151,8 @@ class _AtomSerializer(_TypeSerializer):
         if version >= 5:
             atom._partial_charge = context.read_float()
             atom._atom_type = context.read_using_serializer(self.dict)
+
+        if version >= 7:
+            atom._display_mode = context.read_int()
 
         return atom

--- a/nanome/_internal/_structure/_serialization/_atom_serializer.py
+++ b/nanome/_internal/_structure/_serialization/_atom_serializer.py
@@ -89,7 +89,7 @@ class _AtomSerializer(_TypeSerializer):
             context.write_using_serializer(self.dict, value._atom_type)
 
         if version >= 7:
-            context.WriteInt(value._display_mode)
+            context.write_int(value._display_mode)
 
     def deserialize(self, version, context):
         # type: (_Atom, _ContextDeserialization) -> _Atom

--- a/nanome/api/structure/atom.py
+++ b/nanome/api/structure/atom.py
@@ -60,7 +60,10 @@ class Atom(_Atom, Base):
 
         :type: :class:`bool`
         """
-        self._atom_rendering = value
+        if value:
+            self._display_mode = 0xFFFFFFFF
+        else:
+            self._display_mode = 0x00000000
         self._hydrogened = value
         self._watered = value
         self._hetatomed = value
@@ -380,10 +383,13 @@ class Atom(_Atom, Base):
             self._parent = parent
 
         def set_visible(self, value):
-            self._parent.atom_rendering = value
-            self._parent.hydrogened = value
-            self._parent.watered = value
-            self._parent.hetatomed = value
+            if value:
+                self._parent._display_mode = 0xFFFFFFFF
+            else:
+                self._parent._display_mode = 0x00000000
+            self._parent._hydrogened = value
+            self._parent._watered = value
+            self._parent._hetatomed = value
 
         @property
         def selected(self):


### PR DESCRIPTION
Replaced atom_rendering with a bit manipulation of the display_mode.

I'm not exposing the display_mode yet because we don't have a proper bitflag implementation. But this at least will prevent the plugin from wiping the flag used in nanome core during quick prep.