### PR TITLE
Argparser refactor

### DIFF
--- a/nanome/_internal/_plugin.py
+++ b/nanome/_internal/_plugin.py
@@ -5,10 +5,10 @@ from nanome._internal._network._commands._callbacks._commands_enums import _Hash
 from nanome._internal._network._serialization._serializer import Serializer
 from nanome._internal._util._serializers import _TypeSerializer
 from nanome.util.logs import Logs
-from nanome.util import config
 
 from multiprocessing import Process, Pipe, current_process
 from timeit import default_timer as timer
+import argparse
 import sys
 import json
 import cProfile
@@ -24,65 +24,46 @@ KEEP_ALIVE_TIME_INTERVAL = 60.0
 KEEP_ALIVE_TIMEOUT = 15.0
 
 __metaclass__ = type
+
+
 class _Plugin(object):
     __serializer = Serializer()
     _plugin_id = -1
     _custom_data = None
 
+    def create_parser(self):
+        """Create command line parser For Plugin.
+
+        Some of these flags are passed down into the Plugin, and processed internally.
+        rtype: argsparser: args parser
+        """
+        parser = argparse.ArgumentParser(description='Parse Arguments to set up Nanome Plugin')
+        parser.add_argument('-a', '--host', help='connects to NTS at the specified IP address', required=True)
+        parser.add_argument('-p', '--port', type=int, help='connects to NTS at the specified port', required=True)
+        parser.add_argument('-r', '--auto-reload', action='store_true', help='Restart plugin automatically if a .py or .json file in current directory changes')
+        parser.add_argument('-v', '--verbose', action='store_true', help='enable verbose mode, to display Logs.debug')
+        parser.add_argument('-n', '--name', nargs='+', help='Name to display for this plugin in Nanome')
+        parser.add_argument('-k', '--keyfile', help='Specifies a key file or key string to use to connect to NTS')
+        parser.add_argument('-i', '--ignore', help='To use with auto-reload. All paths matching this pattern will be ignored, use commas to specify several. Supports */?/[seq]/[!seq]')
+        return parser
+
     def __parse_args(self):
         Logs._set_verbose(False)
-        for i in range(1, len(sys.argv)):
-            if sys.argv[i] == "-h":
-                Logs.message("Usage:", sys.argv[1],"[-h] [-a ADDRESS] [-p PORT]")
-                Logs.message(" -h                   display this help")
-                Logs.message(" -a                   connects to a NTS at the specified IP address")
-                Logs.message(" -p                   connects to a NTS at the specified port")
-                Logs.message(" -k                   specifies a key file or key string to use to connect to NTS")
-                Logs.message(" -n                   name to display for this plugin in Nanome")
-                Logs.message(" -v                   enable verbose mode, to display Logs.debug")
-                Logs.message(" -r, --auto-reload    restart plugin automatically if a .py or .json file in current directory changes")
-                Logs.message(" --ignore             to use with auto-reload. All paths matching this pattern will be ignored, " \
-                    "use commas to specify several. Supports */?/[seq]/[!seq]")
-                sys.exit(0)
-            elif sys.argv[i] == "-a":
-                if i >= len(sys.argv):
-                    Logs.error("Error: -a requires an argument")
-                    sys.exit(1)
-                self.__host = sys.argv[i + 1]
-                i += 1
-            elif sys.argv[i] == "-p":
-                if i >= len(sys.argv):
-                    Logs.error("Error: -p requires an argument")
-                    sys.exit(1)
-                try:
-                    self.__port = int(sys.argv[i + 1])
-                except ValueError:
-                    Logs.error("Error: -p argument has to be an integer")
-                    sys.exit(1)
-                i += 1
-            elif sys.argv[i] == "-k":
-                if i >= len(sys.argv):
-                    Logs.error("Error: -k requires an argument")
-                    sys.exit(1)
-                self.__key = sys.argv[i + 1]
-                i += 1
-            elif sys.argv[i] == "-n":
-                if i >= len(sys.argv):
-                    Logs.error("Error: -n requires an argument")
-                    sys.exit(1)
-                self._description['name'] = sys.argv[i + 1]
-                i += 1
-            elif sys.argv[i] == "-v":
-                self.__has_verbose = True
-                Logs._set_verbose(True)
-            elif sys.argv[i] == "-r" or sys.argv[i] == "--auto-reload":
-                self.__has_autoreload = True
-            elif sys.argv[i] == "--ignore":
-                if i >= len(sys.argv):
-                    Logs.error("Error: --ignore requires an argument")
-                    sys.exit(1)
-                split = sys.argv[i + 1].split(",")
-                self.__to_ignore.extend(split)
+        parser = self.create_parser()
+        args = parser.parse_args()
+        self.__host = args.host
+        self.__port = int(args.port)
+        self.__key = args.keyfile
+        self._description['name'] = ' '.join(args.name)
+        self.__has_autoreload = args.auto_reload
+
+        is_verbose = args.verbose
+        self.__has_verbose = is_verbose
+        Logs._set_verbose(is_verbose)
+
+        if args.ignore:
+            split = args.ignore.split(",")
+            self.__to_ignore.extend(split)
 
     def __read_key(self):
         # check if arg is key data
@@ -103,7 +84,7 @@ class _Plugin(object):
             #   Fix 5/27/2021 - Jeremie: We need to always check for session registration in order to fix timeout issues
             #   When NTS forces disconnection because of plugin list change, session_id still exists in self._sessions,
             #   even though it was disconnected for Nanome
-            if _Plugin.__serializer.try_register_session(packet.payload) == True:
+            if _Plugin.__serializer.try_register_session(packet.payload) is True:
                 received_version_table, _, _ = _Plugin.__serializer.deserialize_command(packet.payload, None)
                 version_table = _TypeSerializer.get_best_version_table(received_version_table)
                 self.__on_client_connection(session_id, version_table)
@@ -123,7 +104,7 @@ class _Plugin(object):
 
         elif packet.packet_type == Network._Packet.packet_type_plugin_disconnection:
             if _Plugin._plugin_id == -1:
-                if self._description['auth'] == None:
+                if self._description['auth'] is None:
                     Logs.error("Connection refused by NTS. Are you missing a security key file?")
                 else:
                     Logs.error("Connection refused by NTS. Your security key file might be invalid")
@@ -157,17 +138,17 @@ class _Plugin(object):
                 for pattern in self.__to_ignore:
                     if fnmatch.fnmatch(file_path, pattern):
                         matched = True
-                if matched == False:
+                if matched is False:
                     found_file = True
                     yield os.stat(file_path).st_mtime
-        if found_file == False:
+        if found_file is False:
             yield 0.0
 
     def __autoreload(self):
         wait = 3
 
         if os.name == "nt":
-            sub_kwargs = { 'creationflags': subprocess.CREATE_NEW_PROCESS_GROUP }
+            sub_kwargs = {'creationflags': subprocess.CREATE_NEW_PROCESS_GROUP}
             break_signal = signal.CTRL_BREAK_EVENT
         else:
             sub_kwargs = {}
@@ -201,7 +182,7 @@ class _Plugin(object):
             signal.signal(signal.SIGBREAK, self.__on_termination_signal)
         else:
             signal.signal(signal.SIGTERM, self.__on_termination_signal)
-        if self._pre_run != None:
+        if self._pre_run is not None:
             self._pre_run()
         _Plugin.instance = self
         self._description['auth'] = self.__read_key()
@@ -239,19 +220,19 @@ class _Plugin(object):
             while True:
                 now = timer()
 
-                if self.__connected == False:
+                if self.__connected is False:
                     reconnect_wait = min(2 ** self.__reconnect_attempt, MAX_RECONNECT_WAIT)
                     elapsed = now - self.__disconnection_time
                     if elapsed >= reconnect_wait:
                         Logs.message("Trying to reconnect...")
-                        if self.__connect() == False:
+                        if self.__connect() is False:
                             if self.__reconnect_attempt == 3:
                                 self.__disconnect()
                             continue
                     else:
                         time.sleep(reconnect_wait - elapsed)
                         continue
-                if self._network.receive() == False:
+                if self._network.receive() is False:
                     self.__connected = False
                     self.__disconnection_time = timer()
                     self._network.disconnect()
@@ -271,7 +252,7 @@ class _Plugin(object):
 
                 del to_remove[:]
                 for id, session in self._sessions.items():
-                    if session._read_from_plugin() == False:
+                    if session._read_from_plugin() is False:
                         session.close_pipes()
                         to_remove.append(id)
                 for id in to_remove:
@@ -297,12 +278,12 @@ class _Plugin(object):
         for session in _Plugin.instance._sessions.values():
             session.signal_and_close_pipes()
             session.plugin_process.join()
-        if self._post_run != None:
+        if self._post_run is not None:
             self._post_run()
         sys.exit(0)
 
     def __on_client_connection(self, session_id, version_table):
-        if session_id in self._sessions: # If session_id already exists, close it first ()
+        if session_id in self._sessions:  # If session_id already exists, close it first ()
             Logs.message("Closing session ID", session_id, "because a new session connected with the same ID")
             self._sessions[session_id].signal_and_close_pipes()
         main_conn_net, process_conn_net = Pipe()
@@ -323,8 +304,7 @@ class _Plugin(object):
     def _launch_plugin_profile(cls, plugin_class, session_id, pipe_net, pipe_proc, serializer, plugin_id, version_table, original_version_table, verbose, custom_data, permissions):
         cProfile.runctx('_Plugin._launch_plugin(plugin_class, session_id, pipe_net, pipe_proc, serializer, '
                         'plugin_id, version_table, original_version_table, verbose, custom_data,'
-                        'permissions)'
-                        , globals(), locals(), 'profile.out')
+                        'permissions)', globals(), locals(), 'profile.out')
 
     @classmethod
     def _launch_plugin(cls, plugin_class, session_id, pipe_net, pipe_proc, serializer, plugin_id, version_table, original_version_table, verbose, custom_data, permissions):

--- a/nanome/_internal/_plugin.py
+++ b/nanome/_internal/_plugin.py
@@ -9,7 +9,6 @@ from nanome.util import config
 
 from multiprocessing import Process, Pipe, current_process
 from timeit import default_timer as timer
-import argparse
 import sys
 import json
 import cProfile
@@ -31,39 +30,6 @@ class _Plugin(object):
     __serializer = Serializer()
     _plugin_id = -1
     _custom_data = None
-
-    def create_parser(self):
-        """Create command line parser For Plugin.
-        
-        rtype: argsparser: args parser
-        """
-        parser = argparse.ArgumentParser(description='Parse Arguments to set up Nanome Plugin')
-        parser.add_argument('-a', '--host', help='connects to NTS at the specified IP address', default=config.fetch('host'))
-        parser.add_argument('-p', '--port', type=int, help='connects to NTS at the specified port', default=config.fetch('port'))
-        parser.add_argument('-r', '--auto-reload', action='store_true', help='Restart plugin automatically if a .py or .json file in current directory changes')
-        parser.add_argument('-v', '--verbose', action='store_true', help='enable verbose mode, to display Logs.debug')
-        parser.add_argument('-n', '--name', nargs='+', help='Name to display for this plugin in Nanome', default=list())
-        parser.add_argument('-k', '--keyfile', default='', help='Specifies a key file or key string to use to connect to NTS')
-        parser.add_argument('-i', '--ignore', help='To use with auto-reload. All paths matching this pattern will be ignored, use commas to specify several. Supports */?/[seq]/[!seq]')
-        return parser
-
-    def __parse_args(self):
-        parser = self.create_parser()
-        args = parser.parse_args()
-
-        self.__host = args.host
-        self.__port = int(args.port)
-        self.__key = args.keyfile
-        self._description['name'] = ' '.join(args.name)
-        self.__has_autoreload = args.auto_reload
-
-        is_verbose = args.verbose
-        self.__has_verbose = is_verbose
-        Logs._set_verbose(is_verbose)
-
-        if args.ignore:
-            split = args.ignore.split(",")
-            self.__to_ignore.extend(split)
 
     def __read_key(self):
         # check if arg is key data

--- a/nanome/_internal/_plugin.py
+++ b/nanome/_internal/_plugin.py
@@ -5,7 +5,6 @@ from nanome._internal._network._commands._callbacks._commands_enums import _Hash
 from nanome._internal._network._serialization._serializer import Serializer
 from nanome._internal._util._serializers import _TypeSerializer
 from nanome.util.logs import Logs
-from nanome.util import config
 
 from multiprocessing import Process, Pipe, current_process
 from timeit import default_timer as timer

--- a/nanome/_internal/_plugin.py
+++ b/nanome/_internal/_plugin.py
@@ -33,8 +33,7 @@ class _Plugin(object):
 
     def create_parser(self):
         """Create command line parser For Plugin.
-
-        Some of these flags are passed down into the Plugin, and processed internally.
+        
         rtype: argsparser: args parser
         """
         parser = argparse.ArgumentParser(description='Parse Arguments to set up Nanome Plugin')

--- a/nanome/_internal/_plugin.py
+++ b/nanome/_internal/_plugin.py
@@ -43,14 +43,14 @@ class _Plugin(object):
         parser.add_argument('-r', '--auto-reload', action='store_true', help='Restart plugin automatically if a .py or .json file in current directory changes')
         parser.add_argument('-v', '--verbose', action='store_true', help='enable verbose mode, to display Logs.debug')
         parser.add_argument('-n', '--name', nargs='+', help='Name to display for this plugin in Nanome')
-        parser.add_argument('-k', '--keyfile', help='Specifies a key file or key string to use to connect to NTS')
+        parser.add_argument('-k', '--keyfile', default='', help='Specifies a key file or key string to use to connect to NTS')
         parser.add_argument('-i', '--ignore', help='To use with auto-reload. All paths matching this pattern will be ignored, use commas to specify several. Supports */?/[seq]/[!seq]')
         return parser
 
     def __parse_args(self):
-        Logs._set_verbose(False)
         parser = self.create_parser()
         args = parser.parse_args()
+
         self.__host = args.host
         self.__port = int(args.port)
         self.__key = args.keyfile

--- a/nanome/_internal/_plugin.py
+++ b/nanome/_internal/_plugin.py
@@ -5,6 +5,7 @@ from nanome._internal._network._commands._callbacks._commands_enums import _Hash
 from nanome._internal._network._serialization._serializer import Serializer
 from nanome._internal._util._serializers import _TypeSerializer
 from nanome.util.logs import Logs
+from nanome.util import config
 
 from multiprocessing import Process, Pipe, current_process
 from timeit import default_timer as timer
@@ -37,11 +38,11 @@ class _Plugin(object):
         rtype: argsparser: args parser
         """
         parser = argparse.ArgumentParser(description='Parse Arguments to set up Nanome Plugin')
-        parser.add_argument('-a', '--host', help='connects to NTS at the specified IP address', required=True)
-        parser.add_argument('-p', '--port', type=int, help='connects to NTS at the specified port', required=True)
+        parser.add_argument('-a', '--host', help='connects to NTS at the specified IP address', default=config.fetch('host'))
+        parser.add_argument('-p', '--port', type=int, help='connects to NTS at the specified port', default=config.fetch('port'))
         parser.add_argument('-r', '--auto-reload', action='store_true', help='Restart plugin automatically if a .py or .json file in current directory changes')
         parser.add_argument('-v', '--verbose', action='store_true', help='enable verbose mode, to display Logs.debug')
-        parser.add_argument('-n', '--name', nargs='+', help='Name to display for this plugin in Nanome')
+        parser.add_argument('-n', '--name', nargs='+', help='Name to display for this plugin in Nanome', default=list())
         parser.add_argument('-k', '--keyfile', default='', help='Specifies a key file or key string to use to connect to NTS')
         parser.add_argument('-i', '--ignore', help='To use with auto-reload. All paths matching this pattern will be ignored, use commas to specify several. Supports */?/[seq]/[!seq]')
         return parser

--- a/nanome/api/plugin.py
+++ b/nanome/api/plugin.py
@@ -77,90 +77,27 @@ class Plugin(_Plugin):
         parser = self.create_parser()
         args = parser.parse_args()
 
-        self.host = args.host or default_host
-        self.port = args.port or default_port
-        self.key = args.keyfile or default_key
-        self.has_autoreload = args.auto_reload
+        self.__host = args.host or default_host
+        self.__port = args.port or default_port
+        self.__key = args.keyfile or default_key
+        self.__has_autoreload = args.auto_reload
 
-        self.verbose = args.verbose
+        self.__has_verbose = args.verbose
         Logs._set_verbose(self.verbose)
 
-        if args.ignore:
+        if args.__to_ignore:
             to_ignore = args.ignore.split(",")
-            self.to_ignore.extend(to_ignore)
+            self.__to_ignore.extend(to_ignore)
 
-        # Name can be set during the class instantiation without cli flag.
-        if args.name and not self.name:
-            self.name = args.name
+        # Name can be set during the class instantiation without cli arg.
+        if args.name and not self._description.get('name', None):
+            self._description['name'] = args.name
 
         Logs.debug("Start plugin")
-        if self.has_autoreload:
+        if self.__has_autoreload:
             self.__autoreload()
         else:
             self.__run()
-
-    @property
-    def host(self):
-        """NTS host."""
-        return self.__host
-
-    @host.setter
-    def host(self, value):
-        self.__host = value
-
-    @property
-    def port(self):
-        """NTS port."""
-        return self.__port
-
-    @port.setter
-    def port(self, value):
-        self.__port = value
-
-    @property
-    def key(self):
-        """Specifies a key file or key string to use to connect to NTS."""
-        return self.__key
-
-    @key.setter
-    def key(self, value):
-        self.__key = value
-
-    @property
-    def has_autoreload(self):
-        """Boolean for whether the plugin reloads on python or json file change."""
-        return self.__has_autoreload
-
-    @has_autoreload.setter
-    def has_autoreload(self, value):
-        self.__has_autoreload = value
-
-    @property
-    def name(self):
-        """Name of plugin on the stacks list."""
-        return self._description.get('name')
-
-    @name.setter
-    def name(self, value):
-        self._description['name'] = value
-
-    @property
-    def has_verbose(self):
-        """Boolean for whether to print verbose Logs."""
-        return self.__has_verbose
-
-    @has_verbose.setter
-    def has_verbose(self, value):
-        self.__has_verbose = value
-
-    @property
-    def to_ignore(self):
-        """List of path regexes to be ignored during autoreload."""
-        return self.__to_ignore
-
-    @to_ignore.setter
-    def to_ignore(self, value):
-        self.__to_ignore = value
 
     def set_plugin_class(self, plugin_class):
         """
@@ -199,9 +136,3 @@ class Plugin(_Plugin):
     def __init__(self, name, description, tags=[], has_advanced=False, permissions=[], integrations=[]):
         super(Plugin, self).__init__(name, description, tags, has_advanced, permissions, integrations)
         self._plugin_class = _DefaultPlugin
-        self.host = ''
-        self.port = ''
-        self.key = ''
-        self.to_ignore = []
-        self.has_autoreload = False
-        self.is_verbose = False

--- a/nanome/api/plugin.py
+++ b/nanome/api/plugin.py
@@ -81,7 +81,6 @@ class Plugin(_Plugin):
         self.__port = args.port or default_port
         self.__key = args.keyfile or default_key
         self.__has_autoreload = args.auto_reload
-
         self.__has_verbose = args.verbose
         Logs._set_verbose(args.verbose)
 

--- a/nanome/api/plugin.py
+++ b/nanome/api/plugin.py
@@ -72,7 +72,7 @@ class Plugin(_Plugin):
         default_host = config.fetch('host') if host == 'config' else host
         default_port = config.fetch('port') if port == 'config' else port
         default_key = config.fetch('key') if key == 'config' else key
-        
+
         # Parse command line args and set internal variables.
         parser = self.create_parser()
         args = parser.parse_args()

--- a/nanome/api/plugin.py
+++ b/nanome/api/plugin.py
@@ -90,7 +90,7 @@ class Plugin(_Plugin):
             self.__to_ignore.extend(to_ignore)
 
         # Name can be set during the class instantiation without cli arg.
-        if args.name and not self._description.get('name', None):
+        if args.name:
             self._description['name'] = args.name
 
         Logs.debug("Start plugin")

--- a/nanome/api/plugin.py
+++ b/nanome/api/plugin.py
@@ -27,7 +27,7 @@ class Plugin(_Plugin):
 
         rtype: argsparser: args parser
         """
-        parser = argparse.ArgumentParser(description='Parse Arguments to set up Nanome Plugin')
+        parser = argparse.ArgumentParser(description='Starts a Nanome Plugin.')
         parser.add_argument('-a', '--host', help='connects to NTS at the specified IP address')
         parser.add_argument('-p', '--port', type=int, help='connects to NTS at the specified port')
         parser.add_argument('-r', '--auto-reload', action='store_true', help='Restart plugin automatically if a .py or .json file in current directory changes')

--- a/nanome/api/plugin.py
+++ b/nanome/api/plugin.py
@@ -34,7 +34,7 @@ class Plugin(_Plugin):
         parser.add_argument('-v', '--verbose', action='store_true', help='enable verbose mode, to display Logs.debug')
         parser.add_argument('-n', '--name', nargs='+', help='Name to display for this plugin in Nanome', default=list())
         parser.add_argument('-k', '--keyfile', default='', help='Specifies a key file or key string to use to connect to NTS')
-        parser.add_argument('-i', '--ignore', help='To use with auto-reload. All paths matching this pattern will be ignored, use commas to specify several. Supports */?/[seq]/[!seq]')
+        parser.add_argument('-i', '--ignore', help='To use with auto-reload. All paths matching this pattern will be ignored, use commas to specify several. Supports */?/[seq]/[!seq]', default='')
         return parser
 
     @classmethod
@@ -80,19 +80,18 @@ class Plugin(_Plugin):
         self.host = args.host or default_host
         self.port = args.port or default_port
         self.key = args.keyfile or default_key
-        self.autoreload = args.auto_reload
+        self.has_autoreload = args.auto_reload
 
-        # Name can be set during the class instantiation without cli flag.
-        if not self.name and args.name:
-            self.name = ' '.join(args.name)
-
-        is_verbose = args.verbose
-        self.verbose = is_verbose
-        Logs._set_verbose(is_verbose)
+        self.verbose = args.verbose
+        Logs._set_verbose(self.verbose)
 
         if args.ignore:
-            split = args.ignore.split(",")
-            self.to_ignore.extend(split)
+            to_ignore = args.ignore.split(",")
+            self.to_ignore.extend(to_ignore)
+
+        # Name can be set during the class instantiation without cli flag.
+        if args.name and not self.name:
+            self.name = ' '.join(args.name)
 
         Logs.debug("Start plugin")
         if self.__has_autoreload:
@@ -162,9 +161,6 @@ class Plugin(_Plugin):
     @to_ignore.setter
     def to_ignore(self, value):
         self.__to_ignore = value
-
-    def _parse_args(self, default_host='', default_port='', default_key=''):
-        pass
 
     def set_plugin_class(self, plugin_class):
         """

--- a/nanome/api/plugin.py
+++ b/nanome/api/plugin.py
@@ -21,10 +21,10 @@ class Plugin(_Plugin):
     :param has_advanced: If true, plugin will display an "Advanced Settings" button
     :type has_advanced: :class:`bool`
     """
-    
+
     def create_parser(self):
         """Command Line Interface for Plugins.
-        
+
         rtype: argsparser: args parser
         """
         parser = argparse.ArgumentParser(description='Parse Arguments to set up Nanome Plugin')
@@ -80,27 +80,92 @@ class Plugin(_Plugin):
         else:
             self.__run()
 
+    @property
+    def host(self):
+        """NTS host."""
+        return self.__host
+
+    @host.setter
+    def host(self, value):
+        self.__host = value
+
+    @property
+    def port(self):
+        """NTS port."""
+        return self.__port
+
+    @port.setter
+    def port(self, value):
+        self.__port = value
+
+    @property
+    def key(self):
+        """Security Key for NTS"""
+        return self.__key
+
+    @key.setter
+    def key(self, value):
+        self.__key = value
+
+    @property
+    def autoreload(self):
+        """Boolean for whether the plugin reloads on python or json file change."""
+        return self.__has_autoreload
+
+    @autoreload.setter
+    def autoreload(self, value):
+        self.__has_autoreload = value
+
+    @property
+    def name(self):
+        """Name of plugin on the stacks list."""
+        return self._description.get('name')
+
+    @name.setter
+    def name(self, value):
+        self._description['name'] = value
+
+    @property
+    def verbose(self):
+        """Boolean for whether to print verbose Logs."""
+        return self.__has_verbose
+
+    @verbose.setter
+    def verbose(self, value):
+        self.__has_verbose = value
+
+    @property
+    def ignore_files(self):
+        """List of path regexes to be ignored during autoreload."""
+        if not hasattr(self, '__to_ignore'):
+            self.__to_ignore = []
+        return self.__to_ignore
+
+    @ignore_files.setter
+    def ignore_files(self, value):
+        self.__to_ignore = value
+
     def _parse_args(self, default_host='', default_port='', default_key=''):
         """Parse command line args and set internal variables."""
         parser = self.create_parser()
         args = parser.parse_args()
 
-        self.__host = args.host or default_host
-        self.__port = args.port or default_port
-        self.__key = args.keyfile or default_key
-        self.__has_autoreload = args.auto_reload
-        
+        self.host = args.host or default_host
+        self.port = args.port or default_port
+        self.key = args.keyfile or default_key
+        self.autoreload = args.auto_reload
+
         # Often times the name is set during the class Instantiation
-        if not self._description.get('name') and args.name: 
-            self._description['name'] = ' '.join(args.name)
-        
+        if not self.name and args.name:
+            self.name = ' '.join(args.name)
+
         is_verbose = args.verbose
-        self.__has_verbose = is_verbose
+        self.verbose = is_verbose
         Logs._set_verbose(is_verbose)
 
         if args.ignore:
             split = args.ignore.split(",")
-            self.__to_ignore.extend(split)
+            self.ignore_files.extend(split)
 
     def set_plugin_class(self, plugin_class):
         """
@@ -139,3 +204,10 @@ class Plugin(_Plugin):
     def __init__(self, name, description, tags=[], has_advanced=False, permissions=[], integrations=[]):
         super(Plugin, self).__init__(name, description, tags, has_advanced, permissions, integrations)
         self._plugin_class = _DefaultPlugin
+        self.name = ''
+        self.host = ''
+        self.port = ''
+        self.key = ''
+        self.ignore_files = []
+        self.autoreload = False
+        self.verbose = False

--- a/nanome/api/plugin.py
+++ b/nanome/api/plugin.py
@@ -204,7 +204,6 @@ class Plugin(_Plugin):
     def __init__(self, name, description, tags=[], has_advanced=False, permissions=[], integrations=[]):
         super(Plugin, self).__init__(name, description, tags, has_advanced, permissions, integrations)
         self._plugin_class = _DefaultPlugin
-        self.name = ''
         self.host = ''
         self.port = ''
         self.key = ''

--- a/nanome/api/plugin.py
+++ b/nanome/api/plugin.py
@@ -1,13 +1,9 @@
 from . import _DefaultPlugin
-from nanome._internal import _network as Network, _Plugin, _PluginInstance
+from nanome._internal import _Plugin
 from nanome._internal._process import _ProcessManager
-from nanome._internal._network._serialization._serializer import Serializer
 from nanome.util.logs import Logs
 from nanome.util import config
-from multiprocessing import Process, Pipe
-import sys
-import json
-import cProfile
+
 
 class Plugin(_Plugin):
     """
@@ -24,7 +20,7 @@ class Plugin(_Plugin):
     :type has_advanced: :class:`bool`
     """
     @classmethod
-    def setup(cls, name, description, tags, has_advanced, plugin_class, host = "config", port = "config", key = "config", permissions=[], integrations=[]):
+    def setup(cls, name, description, tags, has_advanced, plugin_class, host="config", port="config", key="config", permissions=[], integrations=[]):
         if not _Plugin._is_process():
             plugin = cls(name, description, tags, has_advanced, permissions, integrations)
             plugin.set_plugin_class(plugin_class)
@@ -44,7 +40,7 @@ class Plugin(_Plugin):
     def set_maximum_processes_count(max_process_nb):
         _ProcessManager._max_process_count = max_process_nb
 
-    def run(self, host = "config", port = "config", key = "config"):
+    def run(self, host="config", port="config", key="config"):
         """
         | Starts the plugin by connecting to the server specified.
         | If arguments (-a, -p) are given when starting plugin, host/port will be ignored.
@@ -91,6 +87,7 @@ class Plugin(_Plugin):
         | Useful when using autoreload
         """
         return self._pre_run
+
     @pre_run.setter
     def pre_run(self, value):
         self._pre_run = value
@@ -102,10 +99,11 @@ class Plugin(_Plugin):
         | Useful when using autoreload
         """
         return self._post_run
+
     @post_run.setter
     def post_run(self, value):
         self._post_run = value
 
-    def __init__(self, name, description, tags=[], has_advanced = False, permissions=[], integrations=[]):
+    def __init__(self, name, description, tags=[], has_advanced=False, permissions=[], integrations=[]):
         super(Plugin, self).__init__(name, description, tags, has_advanced, permissions, integrations)
         self._plugin_class = _DefaultPlugin

--- a/nanome/api/plugin.py
+++ b/nanome/api/plugin.py
@@ -72,8 +72,28 @@ class Plugin(_Plugin):
         default_host = config.fetch('host') if host == 'config' else host
         default_port = config.fetch('port') if port == 'config' else port
         default_key = config.fetch('key') if key == 'config' else key
+        
+        # Parse command line args and set internal variables.
+        parser = self.create_parser()
+        args = parser.parse_args()
 
-        self._parse_args(default_host=default_host, default_port=default_port, default_key=default_key)
+        self.host = args.host or default_host
+        self.port = args.port or default_port
+        self.key = args.keyfile or default_key
+        self.autoreload = args.auto_reload
+
+        # Name can be set during the class instantiation without cli flag.
+        if not self.name and args.name:
+            self.name = ' '.join(args.name)
+
+        is_verbose = args.verbose
+        self.verbose = is_verbose
+        Logs._set_verbose(is_verbose)
+
+        if args.ignore:
+            split = args.ignore.split(",")
+            self.to_ignore.extend(split)
+
         Logs.debug("Start plugin")
         if self.__has_autoreload:
             self.__autoreload()
@@ -144,26 +164,7 @@ class Plugin(_Plugin):
         self.__to_ignore = value
 
     def _parse_args(self, default_host='', default_port='', default_key=''):
-        """Parse command line args and set internal variables."""
-        parser = self.create_parser()
-        args = parser.parse_args()
-
-        self.host = args.host or default_host
-        self.port = args.port or default_port
-        self.key = args.keyfile or default_key
-        self.autoreload = args.auto_reload
-
-        # Name is set during the class instantiation.
-        if not self.name and args.name:
-            self.name = ' '.join(args.name)
-
-        is_verbose = args.verbose
-        self.verbose = is_verbose
-        Logs._set_verbose(is_verbose)
-
-        if args.ignore:
-            split = args.ignore.split(",")
-            self.to_ignore.extend(split)
+        pass
 
     def set_plugin_class(self, plugin_class):
         """

--- a/nanome/api/plugin.py
+++ b/nanome/api/plugin.py
@@ -100,7 +100,7 @@ class Plugin(_Plugin):
 
     @property
     def key(self):
-        """Security Key for NTS"""
+        """Specifies a key file or key string to use to connect to NTS."""
         return self.__key
 
     @key.setter
@@ -108,12 +108,12 @@ class Plugin(_Plugin):
         self.__key = value
 
     @property
-    def autoreload(self):
+    def has_autoreload(self):
         """Boolean for whether the plugin reloads on python or json file change."""
         return self.__has_autoreload
 
-    @autoreload.setter
-    def autoreload(self, value):
+    @has_autoreload.setter
+    def has_autoreload(self, value):
         self.__has_autoreload = value
 
     @property
@@ -126,23 +126,21 @@ class Plugin(_Plugin):
         self._description['name'] = value
 
     @property
-    def verbose(self):
+    def has_verbose(self):
         """Boolean for whether to print verbose Logs."""
         return self.__has_verbose
 
-    @verbose.setter
-    def verbose(self, value):
+    @has_verbose.setter
+    def has_verbose(self, value):
         self.__has_verbose = value
 
     @property
-    def ignore_files(self):
+    def to_ignore(self):
         """List of path regexes to be ignored during autoreload."""
-        if not hasattr(self, '__to_ignore'):
-            self.__to_ignore = []
         return self.__to_ignore
 
-    @ignore_files.setter
-    def ignore_files(self, value):
+    @to_ignore.setter
+    def to_ignore(self, value):
         self.__to_ignore = value
 
     def _parse_args(self, default_host='', default_port='', default_key=''):
@@ -155,7 +153,7 @@ class Plugin(_Plugin):
         self.key = args.keyfile or default_key
         self.autoreload = args.auto_reload
 
-        # Often times the name is set during the class Instantiation
+        # Name is set during the class instantiation.
         if not self.name and args.name:
             self.name = ' '.join(args.name)
 
@@ -165,7 +163,7 @@ class Plugin(_Plugin):
 
         if args.ignore:
             split = args.ignore.split(",")
-            self.ignore_files.extend(split)
+            self.to_ignore.extend(split)
 
     def set_plugin_class(self, plugin_class):
         """
@@ -207,6 +205,6 @@ class Plugin(_Plugin):
         self.host = ''
         self.port = ''
         self.key = ''
-        self.ignore_files = []
-        self.autoreload = False
-        self.verbose = False
+        self.to_ignore = []
+        self.has_autoreload = False
+        self.is_verbose = False

--- a/nanome/api/plugin.py
+++ b/nanome/api/plugin.py
@@ -32,7 +32,7 @@ class Plugin(_Plugin):
         parser.add_argument('-p', '--port', type=int, help='connects to NTS at the specified port')
         parser.add_argument('-r', '--auto-reload', action='store_true', help='Restart plugin automatically if a .py or .json file in current directory changes')
         parser.add_argument('-v', '--verbose', action='store_true', help='enable verbose mode, to display Logs.debug')
-        parser.add_argument('-n', '--name', nargs='+', help='Name to display for this plugin in Nanome', default=list())
+        parser.add_argument('-n', '--name', help='Name to display for this plugin in Nanome', default='')
         parser.add_argument('-k', '--keyfile', default='', help='Specifies a key file or key string to use to connect to NTS')
         parser.add_argument('-i', '--ignore', help='To use with auto-reload. All paths matching this pattern will be ignored, use commas to specify several. Supports */?/[seq]/[!seq]', default='')
         return parser
@@ -91,7 +91,7 @@ class Plugin(_Plugin):
 
         # Name can be set during the class instantiation without cli flag.
         if args.name and not self.name:
-            self.name = ' '.join(args.name)
+            self.name = args.name
 
         Logs.debug("Start plugin")
         if self.has_autoreload:

--- a/nanome/api/plugin.py
+++ b/nanome/api/plugin.py
@@ -83,9 +83,9 @@ class Plugin(_Plugin):
         self.__has_autoreload = args.auto_reload
 
         self.__has_verbose = args.verbose
-        Logs._set_verbose(self.verbose)
+        Logs._set_verbose(args.verbose)
 
-        if args.__to_ignore:
+        if args.ignore:
             to_ignore = args.ignore.split(",")
             self.__to_ignore.extend(to_ignore)
 

--- a/nanome/api/plugin.py
+++ b/nanome/api/plugin.py
@@ -94,7 +94,7 @@ class Plugin(_Plugin):
             self.name = ' '.join(args.name)
 
         Logs.debug("Start plugin")
-        if self.__has_autoreload:
+        if self.has_autoreload:
             self.__autoreload()
         else:
             self.__run()


### PR DESCRIPTION
- Move command line arg parsing into `Plugin`, since they are set by the user.
- Use argparse library instead of manually looping through sys.argv
- General spacing and formatting fixes.