### PR TITLE
Fix async process race condition

### DIFF
--- a/nanome/_internal/_process/_process_manager_instance.py
+++ b/nanome/_internal/_process/_process_manager_instance.py
@@ -10,6 +10,7 @@ class _ProcessManagerInstance():
         Process._manager = self
         self.__pending_start = deque()
         self.__processes = dict()
+        self.__futures = dict()
 
     def _close(self):
         self.__pipe.close()
@@ -40,9 +41,9 @@ class _ProcessManagerInstance():
             self.__processes[data[1]].on_start()
         elif type == _ProcessManager._DataType.done:
             process = self.__processes[data[1]]
-            process.on_done(data[2])
             if process._future is not None:
                 process._future.set_result(data[2])
+            process.on_done(data[2])
         elif type == _ProcessManager._DataType.error:
             self.__processes[data[1]].on_error(data[2])
         elif type == _ProcessManager._DataType.output:

--- a/nanome/_internal/_process/_process_manager_instance.py
+++ b/nanome/_internal/_process/_process_manager_instance.py
@@ -10,7 +10,6 @@ class _ProcessManagerInstance():
         Process._manager = self
         self.__pending_start = deque()
         self.__processes = dict()
-        self.__futures = dict()
 
     def _close(self):
         self.__pipe.close()


### PR DESCRIPTION
Process API had a weird race condition with processes that used both asyncio and `on_done`.

Case in point: bonding (also dssp)
- When bonding is run on multiple structures, it reuses the `Process` object for multiple runs of the bonding process.
- To do this, it sets up the input and calls `start` on the `Process` after the previous run's `on_done`.
- Problem was, for async plugins, `start` creates a new `Future`, but the result of the `Future` was being set _after_ `on_done`.

So, bonding would run once, create a `Future`, finish and call `on_done` which then started a new process, _then_ attempt to set the first run's `Future` result which at this point was now a new `Future` from the second run. Not good. But now fixed. :D