### PR TITLE
Fix destroy_multiple bug

### DIFF
--- a/nanome/_internal/_plugin_instance_async.py
+++ b/nanome/_internal/_plugin_instance_async.py
@@ -21,7 +21,9 @@ async def _async_update_loop(self, UPDATE_RATE, MINIMUM_SLEEP):
         self._on_stop()
         return
     except:
-        Logs.error(traceback.format_exc())
+        msg = traceback.format_exc()
+        print(msg)
+        Logs.error(msg)
         self._on_stop()
         self._process_manager._close()
         self._network._close()

--- a/nanome/_internal/_plugin_instance_async.py
+++ b/nanome/_internal/_plugin_instance_async.py
@@ -22,6 +22,8 @@ async def _async_update_loop(self, UPDATE_RATE, MINIMUM_SLEEP):
         return
     except:
         msg = traceback.format_exc()
+        # Print manually because for some reason Logs.error doesn't display it.
+        # TODO: Investigate why.
         print(msg)
         Logs.error(msg)
         self._on_stop()

--- a/nanome/_internal/_shapes/_shape.py
+++ b/nanome/_internal/_shapes/_shape.py
@@ -61,8 +61,8 @@ class _Shape(object):
         result = nanome.PluginInstance._save_callback(id, set_callback if done_callback else None)
         if done_callback is None and nanome.PluginInstance._instance.is_async:
             result.real_set_result = result.set_result
-            result.set_result = lambda args: set_callback(*args)
-            done_callback = lambda *args: result.real_set_result(args)
+            result.set_result = lambda args: set_callback(args)
+            done_callback = lambda args: result.real_set_result(args)
         return result
 
     @classmethod
@@ -77,5 +77,5 @@ class _Shape(object):
         if done_callback is None and nanome.PluginInstance._instance.is_async:
             result.real_set_result = result.set_result
             result.set_result = lambda args: set_callback(args)
-            done_callback = lambda *args: result.real_set_result(args)
+            done_callback = lambda args: result.real_set_result(args)
         return result

--- a/nanome/_internal/_shapes/_shape.py
+++ b/nanome/_internal/_shapes/_shape.py
@@ -76,6 +76,6 @@ class _Shape(object):
         result = nanome.PluginInstance._save_callback(id, set_callback if done_callback else None)
         if done_callback is None and nanome.PluginInstance._instance.is_async:
             result.real_set_result = result.set_result
-            result.set_result = lambda args: set_callback(*args)
+            result.set_result = lambda args: set_callback(args)
             done_callback = lambda *args: result.real_set_result(args)
         return result

--- a/nanome/_internal/_shapes/_shape.py
+++ b/nanome/_internal/_shapes/_shape.py
@@ -62,7 +62,7 @@ class _Shape(object):
         if done_callback is None and nanome.PluginInstance._instance.is_async:
             result.real_set_result = result.set_result
             result.set_result = lambda args: set_callback(args)
-            done_callback = lambda args: result.real_set_result(args)
+            def done_callback(args): return result.real_set_result(args)
         return result
 
     @classmethod
@@ -77,5 +77,5 @@ class _Shape(object):
         if done_callback is None and nanome.PluginInstance._instance.is_async:
             result.real_set_result = result.set_result
             result.set_result = lambda args: set_callback(args)
-            done_callback = lambda args: result.real_set_result(args)
+            def done_callback(args): return result.real_set_result(args)
         return result

--- a/nanome/api/shapes/shape.py
+++ b/nanome/api/shapes/shape.py
@@ -87,7 +87,7 @@ class Shape(_Shape):
             if done_callback is None and nanome.PluginInstance._instance.is_async:
                 loop = asyncio.get_event_loop()
                 future = loop.create_future()
-                done_callback = lambda *args: future.set_result(args)
+                done_callback = lambda args: future.set_result(args)
 
             results = []
 
@@ -113,7 +113,7 @@ class Shape(_Shape):
         | Remove multiple shapes from the Nanome App and destroy them.
         """
         try:
-            _Shape._destroy_multiple(shapes, done_callback)
+            return _Shape._destroy_multiple(shapes, done_callback)
         except TypeError:
             # If destroy multiple fails, upload each one at a time.
             # Done as a fallback for older versions of Nanome that don't support
@@ -125,7 +125,7 @@ class Shape(_Shape):
             if done_callback is None and nanome.PluginInstance._instance.is_async:
                 loop = asyncio.get_event_loop()
                 future = loop.create_future()
-                done_callback = lambda *args: future.set_result(args)
+                done_callback = lambda args: future.set_result(args)
 
             results = []
 

--- a/nanome/api/shapes/shape.py
+++ b/nanome/api/shapes/shape.py
@@ -87,7 +87,7 @@ class Shape(_Shape):
             if done_callback is None and nanome.PluginInstance._instance.is_async:
                 loop = asyncio.get_event_loop()
                 future = loop.create_future()
-                done_callback = lambda args: future.set_result(args)
+                def done_callback(args): return future.set_result(args)
 
             results = []
 
@@ -125,7 +125,7 @@ class Shape(_Shape):
             if done_callback is None and nanome.PluginInstance._instance.is_async:
                 loop = asyncio.get_event_loop()
                 future = loop.create_future()
-                done_callback = lambda args: future.set_result(args)
+                def done_callback(args): return future.set_result(args)
 
             results = []
 


### PR DESCRIPTION
quick debrief on the cause:

- asyncio futures can only have a single result
- when we asyncified upload_multiple, there were 2 return values (indices and results), so we had to pack/unpack them for the future and callback
- Code was probably just copied without knowing what the *args was for, and it wasn't needed for destroy since there's only one arg (results)
- additionally, shape.py destroy_multiple wasn't returning the future from calling _destroy_multiple