### PR TITLE
Fix bug in printing for nanome-setup-plugins function

### DIFF
--- a/nanome/setup_config.py
+++ b/nanome/setup_config.py
@@ -42,7 +42,7 @@ def interactive_mode():
         config_key = argument.dest
         if config_key == 'help':
             continue
-        
+
         print("==============================")
         print(config_key + " (" + argument.help + ")")
         print("Current Value: {}".format(config.fetch(config_key)))

--- a/nanome/setup_config.py
+++ b/nanome/setup_config.py
@@ -40,10 +40,7 @@ def create_parser():
 
 def interactive_mode():
     """Set config values one by one using input from the user."""
-    logger.info("""
-        Setup utility for Nanome Plugins global configuration. 
-        run without arguments for interactive mode.
-    """)
+    logger.info('\nSetup global configurations for Nanome Plugins.\n')
 
     parser = create_parser()
     for argument in parser._actions:

--- a/nanome/setup_config.py
+++ b/nanome/setup_config.py
@@ -1,13 +1,8 @@
 import argparse
 import sys
-import logging
 
 from nanome.util import config
 
-
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
-logger.addHandler(logging.StreamHandler())
 
 def create_parser():
     """Arguments used to set global config values.
@@ -19,7 +14,7 @@ def create_parser():
             'Run without arguments for interactive mode'
         )
     )
-    parser.add_argument('-a', '--host', dest='host', help='NTS server address')
+    parser.add_argument('-a', '--host', dest='host', help='NTS address')
     parser.add_argument('-p', '--port', type=int, dest='port', help='NTS server port')
     parser.add_argument('-k', '--key', dest='key', help='NTS authentication key file or string')
     parser.add_argument(
@@ -40,7 +35,7 @@ def create_parser():
 
 def interactive_mode():
     """Set config values one by one using input from the user."""
-    logger.info('\nSetup global configurations for Nanome Plugins.\n')
+    print('\nSetup global configurations for Nanome Plugins.\n')
 
     parser = create_parser()
     for argument in parser._actions:
@@ -48,9 +43,9 @@ def interactive_mode():
         if config_key == 'help':
             continue
         
-        logger.info("==============================")
-        logger.info(config_key + " (" + argument.help + ")")
-        logger.info("Current Value: {}".format(config.fetch(config_key)))
+        print("==============================")
+        print(config_key + " (" + argument.help + ")")
+        print("Current Value: {}".format(config.fetch(config_key)))
         user_input = input("New Value (leave empty if unchanged): ")
         user_input = user_input.strip()
         if user_input == '':

--- a/nanome/setup_config.py
+++ b/nanome/setup_config.py
@@ -1,12 +1,16 @@
 import argparse
 import sys
+import logging
 
-from nanome.util import config, Logs
+from nanome.util import config
 
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+logger.addHandler(logging.StreamHandler())
 
 def create_parser():
     """Arguments used to set global config values.
-
     rtype: argsparser: args parser
     """
     parser = argparse.ArgumentParser(
@@ -15,9 +19,9 @@ def create_parser():
             'Run without arguments for interactive mode'
         )
     )
-    parser.add_argument('-a', '--host', dest='host', help='Plugin server address')
-    parser.add_argument('-p', '--port', type=int, dest='port', help='Plugin server port')
-    parser.add_argument('-k', '--key', dest='key', help='Plugin authentication key file or string')
+    parser.add_argument('-a', '--host', dest='host', help='NTS server address')
+    parser.add_argument('-p', '--port', type=int, dest='port', help='NTS server port')
+    parser.add_argument('-k', '--key', dest='key', help='NTS authentication key file or string')
     parser.add_argument(
         '-f', '--files_path',
         dest='plugin_files_path',
@@ -36,19 +40,20 @@ def create_parser():
 
 def interactive_mode():
     """Set config values one by one using input from the user."""
-    Logs.message(
-        "Setup utility for Nanome Plugins global configuration. "
-        "run without arguments for interactive mode.")
+    logger.info("""
+        Setup utility for Nanome Plugins global configuration. 
+        run without arguments for interactive mode.
+    """)
 
     parser = create_parser()
     for argument in parser._actions:
         config_key = argument.dest
         if config_key == 'help':
             continue
-
-        Logs.message("==============================")
-        Logs.message(config_key + " (" + argument.help + ")")
-        Logs.message("Current Value:", config.fetch(config_key))
+        
+        logger.info("==============================")
+        logger.info(config_key + " (" + argument.help + ")")
+        logger.info("Current Value: {}".format(config.fetch(config_key)))
         user_input = input("New Value (leave empty if unchanged): ")
         user_input = user_input.strip()
         if user_input == '':

--- a/nanome/setup_config.py
+++ b/nanome/setup_config.py
@@ -14,8 +14,8 @@ def create_parser():
             'Run without arguments for interactive mode'
         )
     )
-    parser.add_argument('-a', '--host', dest='host', help='NTS address')
-    parser.add_argument('-p', '--port', type=int, dest='port', help='NTS server port')
+    parser.add_argument('-a', '--host', dest='host', help='NTS host or IP')
+    parser.add_argument('-p', '--port', type=int, dest='port', help='NTS port')
     parser.add_argument('-k', '--key', dest='key', help='NTS authentication key file or string')
     parser.add_argument(
         '-f', '--files_path',


### PR DESCRIPTION
After logging refactor, when Logs.message is called outside of running plugin, there are no handlers to display log messages.

Add basic logger and handler so messages are shown in the console