### PR TITLE
Verbose logs fix

### DIFF
--- a/nanome/_internal/_network/_net_instance.py
+++ b/nanome/_internal/_network/_net_instance.py
@@ -6,7 +6,6 @@ import socket
 import ssl
 import errno
 import time
-import traceback
 
 
 class _NetInstance(object):
@@ -74,8 +73,10 @@ class _NetInstance(object):
             return False
         except KeyboardInterrupt:
             raise
-        except:
-            Logs.error(traceback.format_exc())
+        except Exception as e:
+            msg = "Uncaught {}: {}".format(type(e).__name__, e.reason) 
+            Logs.error(msg)
+            time.sleep(0.1)
             return False
         else:
             if len(data) == 0:

--- a/nanome/_internal/_network/_net_instance.py
+++ b/nanome/_internal/_network/_net_instance.py
@@ -74,7 +74,7 @@ class _NetInstance(object):
         except KeyboardInterrupt:
             raise
         except Exception as e:
-            msg = "Uncaught {}: {}".format(type(e).__name__, e.reason) 
+            msg = "Uncaught {}: {}".format(type(e).__name__, e.reason)
             Logs.error(msg)
             time.sleep(0.1)
             return False

--- a/nanome/_internal/_plugin.py
+++ b/nanome/_internal/_plugin.py
@@ -285,7 +285,7 @@ class _Plugin(object):
         )
         process.start()
         session.plugin_process = process
-        self._sessions[session_id] = sessionf
+        self._sessions[session_id] = session
         logger.debug("Registered new session: {}".format(session_id))
 
     def __logs_request(self, packet):

--- a/nanome/_internal/_plugin.py
+++ b/nanome/_internal/_plugin.py
@@ -269,14 +269,13 @@ class _Plugin(object):
             session_id, self._network, self._process_manager, self._logs_manager,
             main_conn_net, main_conn_proc)
         permissions = self._description["permissions"]
-        is_verbose = True
         process = Process(
             target=self._launch_plugin,
             args=(
                 self._plugin_class, session_id, process_conn_net,
                 process_conn_proc, self.__serializer, self._plugin_id,
                 version_table, _TypeSerializer.get_version_table(),
-                is_verbose, self._custom_data, permissions
+                self._custom_data, permissions
             )
         )
         process.start()
@@ -313,10 +312,10 @@ class _Plugin(object):
                         'permissions)', globals(), locals(), 'profile.out')
 
     @classmethod
-    def _launch_plugin(cls, plugin_class, session_id, pipe_net, pipe_proc, serializer, plugin_id, version_table, original_version_table, verbose, custom_data, permissions):
+    def _launch_plugin(cls, plugin_class, session_id, pipe_net, pipe_proc, serializer, plugin_id, version_table, original_version_table, custom_data, permissions):
         plugin = plugin_class()
 
-        _PluginInstance.__init__(plugin, session_id, pipe_net, pipe_proc, serializer, plugin_id, version_table, original_version_table, verbose, custom_data, permissions)
+        _PluginInstance.__init__(plugin, session_id, pipe_net, pipe_proc, serializer, plugin_id, version_table, original_version_table, custom_data, permissions)
         LogsManager.configure_child_process(pipe_proc, plugin_class)
         logger.debug("Starting plugin")
         plugin._run()

--- a/nanome/_internal/_plugin.py
+++ b/nanome/_internal/_plugin.py
@@ -270,9 +270,9 @@ class _Plugin(object):
             session_id, self._network, self._process_manager, self._logs_manager,
             main_conn_net, main_conn_proc)
         permissions = self._description["permissions"]
-        
+
         # Ensures consistent behavior between Windows and Linux
-        multiprocessing.set_start_method('spawn')  
+        multiprocessing.set_start_method('spawn')
 
         process = Process(
             target=self._launch_plugin,

--- a/nanome/_internal/_plugin.py
+++ b/nanome/_internal/_plugin.py
@@ -7,6 +7,7 @@ from nanome._internal._util._serializers import _TypeSerializer
 from nanome._internal.logs import LogsManager
 import logging
 
+import multiprocessing
 from multiprocessing import Process, Pipe, current_process
 from timeit import default_timer as timer
 import sys
@@ -269,6 +270,7 @@ class _Plugin(object):
             session_id, self._network, self._process_manager, self._logs_manager,
             main_conn_net, main_conn_proc)
         permissions = self._description["permissions"]
+        multiprocessing.set_start_method('spawn')
         process = Process(
             target=self._launch_plugin,
             args=(
@@ -314,7 +316,6 @@ class _Plugin(object):
     @classmethod
     def _launch_plugin(cls, plugin_class, session_id, pipe_net, pipe_proc, serializer, plugin_id, version_table, original_version_table, custom_data, permissions):
         plugin = plugin_class()
-
         _PluginInstance.__init__(plugin, session_id, pipe_net, pipe_proc, serializer, plugin_id, version_table, original_version_table, custom_data, permissions)
         LogsManager.configure_child_process(pipe_proc, plugin_class)
         logger.debug("Starting plugin")

--- a/nanome/_internal/_plugin.py
+++ b/nanome/_internal/_plugin.py
@@ -270,7 +270,10 @@ class _Plugin(object):
             session_id, self._network, self._process_manager, self._logs_manager,
             main_conn_net, main_conn_proc)
         permissions = self._description["permissions"]
-        multiprocessing.set_start_method('spawn')
+        
+        # Ensures consistent behavior between Windows and Linux
+        multiprocessing.set_start_method('spawn')  
+
         process = Process(
             target=self._launch_plugin,
             args=(
@@ -282,7 +285,7 @@ class _Plugin(object):
         )
         process.start()
         session.plugin_process = process
-        self._sessions[session_id] = session
+        self._sessions[session_id] = sessionf
         logger.debug("Registered new session: {}".format(session_id))
 
     def __logs_request(self, packet):

--- a/nanome/_internal/_plugin_instance.py
+++ b/nanome/_internal/_plugin_instance.py
@@ -122,7 +122,7 @@ class _PluginInstance(object):
     def _has_permission(self, permission):
         return _Hashes.PermissionRequestHashes[permission] in self._permissions
 
-    def __init__(self, session_id, net_pipe, proc_pipe, serializer, plugin_id, version_table, original_version_table, verbose, custom_data, permissions):
+    def __init__(self, session_id, net_pipe, proc_pipe, serializer, plugin_id, version_table, original_version_table, custom_data, permissions):
         self._menus = {}
 
         self._network = _ProcessNetwork(self, session_id, net_pipe, serializer, plugin_id, version_table)

--- a/nanome/_internal/logs.py
+++ b/nanome/_internal/logs.py
@@ -124,15 +124,16 @@ class LogsManager():
         plugin_logger = logging.getLogger(plugin_module)
         plugin_logger.setLevel(logging_level)
 
+        existing_handler_types = set([type(hdlr) for hdlr in lib_logger.handlers])
+
         self.console_handler = self.create_console_handler()
         self.log_file_handler = logging.NullHandler()
         self.nts_handler = logging.NullHandler()
 
-        # If timezone not specified, set to UTC
-        if not os.environ.get('TZ'):
-            os.environ['TZ'] = 'UTC'
+        if type(self.console_handler) not in existing_handler_types:
+            lib_logger.addHandler(self.console_handler)
+            plugin_logger.addHandler(self.console_handler)
 
-        existing_handler_types = set([type(hdlr) for hdlr in lib_logger.handlers])
         if self.write_log_file and self.filename:
             self.log_file_handler = self.create_log_file_handler(self.filename)
             self.log_file_handler.setLevel(logging_level)
@@ -147,9 +148,9 @@ class LogsManager():
                 lib_logger.addHandler(self.nts_handler)
                 plugin_logger.addHandler(self.nts_handler)
 
-        if type(self.console_handler) not in existing_handler_types:
-            lib_logger.addHandler(self.console_handler)
-            plugin_logger.addHandler(self.console_handler)
+        # If timezone not specified, set to UTC
+        if not os.environ.get('TZ'):
+            os.environ['TZ'] = 'UTC'
 
     @staticmethod
     def configure_child_process(pipe_conn, plugin_class):
@@ -157,16 +158,16 @@ class LogsManager():
         # reset loggers on nanome-lib.
         nanome_logger = logging.getLogger("nanome")
         nanome_logger.handlers = []
-        nanome_logger.setLevel(logging.DEBUG)
+        nanome_logger.setLevel(logging.INFO)
 
         # make sure plugin module is logged
         plugin_module = plugin_class.__module__.split('.')[0]
         plugin_logger = logging.getLogger(plugin_module)
         plugin_logger.handlers = []
-        plugin_logger.setLevel(logging.DEBUG)
+        plugin_logger.setLevel(logging.INFO)
 
         pipe_handler = PipeHandler(pipe_conn)
-        pipe_handler.level = logging.DEBUG
+        pipe_handler.level = logging.INFO
 
         nanome_logger.addHandler(pipe_handler)
         plugin_logger.addHandler(pipe_handler)

--- a/nanome/_internal/logs.py
+++ b/nanome/_internal/logs.py
@@ -158,16 +158,18 @@ class LogsManager():
         # reset loggers on nanome-lib.
         nanome_logger = logging.getLogger("nanome")
         nanome_logger.handlers = []
-        nanome_logger.setLevel(logging.INFO)
+        nanome_logger.setLevel(logging.DEBUG)
 
         # make sure plugin module is logged
         plugin_module = plugin_class.__module__.split('.')[0]
         plugin_logger = logging.getLogger(plugin_module)
         plugin_logger.handlers = []
-        plugin_logger.setLevel(logging.INFO)
+        plugin_logger.setLevel(logging.DEBUG)
 
+        # Pipe should send all logs to main process
+        # If debug logs are disabled, they will be filtered in main process.
         pipe_handler = PipeHandler(pipe_conn)
-        pipe_handler.level = logging.INFO
+        pipe_handler.level = logging.DEBUG
 
         nanome_logger.addHandler(pipe_handler)
         plugin_logger.addHandler(pipe_handler)

--- a/nanome/api/plugin.py
+++ b/nanome/api/plugin.py
@@ -7,6 +7,18 @@ from nanome.util.logs import Logs
 from nanome.util import config
 
 
+def str2bool(v):
+    """Accept various truthy/falsey values as boolean arguments."""
+    if isinstance(v, bool):
+        return v
+    if v.lower() in ('yes', 'true', 't', 'y', '1'):
+        return True
+    elif v.lower() in ('no', 'false', 'f', 'n', '0'):
+        return False
+    else:
+        raise argparse.ArgumentTypeError('Boolean value expected.')
+
+
 class Plugin(_Plugin):
     """Process that connects to NTS, and allows a user to access a PluginInstance.
 
@@ -49,8 +61,8 @@ class Plugin(_Plugin):
         parser.add_argument('-n', '--name', help='Name to display for this plugin in Nanome', default='')
         parser.add_argument('-k', '--keyfile', default='', help='Specifies a key file or key string to use to connect to NTS')
         parser.add_argument('-i', '--ignore', help='To use with auto-reload. All paths matching this pattern will be ignored, use commas to specify several. Supports */?/[seq]/[!seq]', default='')
-        parser.add_argument('--write-log-file', type=bool, help='Enable or disable writing logs to .log file')
-        parser.add_argument('--remote-logging', type=bool, dest='remote_logging', help='Toggle whether or not logs should be forwarded to NTS.')
+        parser.add_argument('--write-log-file', type=str2bool, help='Enable or disable writing logs to .log file')
+        parser.add_argument('--remote-logging', type=str2bool, dest='remote_logging', help='Toggle whether or not logs should be forwarded to NTS.')
         return parser
 
     def run(self, host="config", port="config", key="config"):

--- a/testing/plugin_tests.py
+++ b/testing/plugin_tests.py
@@ -41,13 +41,15 @@ class PluginTestCase(unittest.TestCase):
         send_mock.assert_called_once()
 
         # Test with different args set
-        write_log_file = "True"
+        write_log_file = "yes"
+        remote_logging = "false"
         ignore = 'fake_file.py'
         name = 'custom plugin name'
         testargs = [
             'run.py',
             '--auto-reload',
             '--write-log-file', write_log_file,
+            '--remote-logging', remote_logging,
             '--ignore', ignore,
             '--name', name,
             '--verbose'
@@ -55,6 +57,7 @@ class PluginTestCase(unittest.TestCase):
         with patch.object(sys, 'argv', testargs):
             self.plugin.run(host, port, key)
         self.assertEqual(self.plugin.write_log_file, True)
+        self.assertEqual(self.plugin.remote_logging, False)
         self.assertEqual(self.plugin.to_ignore, [ignore])
         self.assertEqual(self.plugin.name, name)
         self.assertEqual(self.plugin.verbose, True)


### PR DESCRIPTION
Fix issue where setting the --verbose plugin flag caused remote logging to crash on NTS.

- Set process start method to spawn, so we should now have consistent behavior between Linux and Windows.
 
- Remove verbose arg from PluginInstance init, because it wasn't used
 
- Make console handler first log handler, so if remote call fails we can still see the output in the console

- Tidy up exception logging in NetInstance

- Fix bug where setting --remote-logging as anything made it true (Now accepts false values)