### PR TITLE
Set start method fix

### DIFF
--- a/nanome/_internal/_plugin.py
+++ b/nanome/_internal/_plugin.py
@@ -35,10 +35,6 @@ class _Plugin(object):
     _custom_data = None
 
     def _run(self):
-        # Ensures consistent behavior between Windows and Linux
-        # Commented out for now because crashes on Linux :/
-        multiprocessing.set_start_method('spawn')
-
         if os.name == "nt":
             signal.signal(signal.SIGBREAK, self.__on_termination_signal)
         else:
@@ -268,6 +264,9 @@ class _Plugin(object):
         if session_id in self._sessions:  # If session_id already exists, close it first ()
             logger.info("Closing session ID {} because a new session connected with the same ID".format(session_id))
             self._sessions[session_id].signal_and_close_pipes()
+
+        # set_start_method ensures consistent process behavior between Windows and Linux
+        multiprocessing.set_start_method('spawn')
         main_conn_net = Queue()
         process_conn_net = Queue()
         main_conn_proc, process_conn_proc = Pipe()

--- a/nanome/_internal/_plugin.py
+++ b/nanome/_internal/_plugin.py
@@ -35,6 +35,10 @@ class _Plugin(object):
     _custom_data = None
 
     def _run(self):
+        # Ensures consistent behavior between Windows and Linux
+        # Commented out for now because crashes on Linux :/
+        multiprocessing.set_start_method('spawn')
+
         if os.name == "nt":
             signal.signal(signal.SIGBREAK, self.__on_termination_signal)
         else:
@@ -271,10 +275,6 @@ class _Plugin(object):
             session_id, self._network, self._process_manager, self._logs_manager,
             main_conn_net, process_conn_net, main_conn_proc)
         permissions = self._description["permissions"]
-
-        # Ensures consistent behavior between Windows and Linux
-        # Commented out for now because crashes on Linux :/
-        # multiprocessing.set_start_method('spawn')
 
         process = Process(
             target=self._launch_plugin,

--- a/nanome/_internal/_plugin.py
+++ b/nanome/_internal/_plugin.py
@@ -110,7 +110,7 @@ class _Plugin(object):
                 id = packet.session_id
                 self._sessions[id].signal_and_close_pipes()
                 del self._sessions[id]
-                logger.debug("Session {} disconnected".format(id))
+                logger.info("Session {} disconnected".format(id))
             except Exception:
                 pass
         elif packet.packet_type == Network._Packet.packet_type_keep_alive:

--- a/nanome/_internal/_plugin.py
+++ b/nanome/_internal/_plugin.py
@@ -288,7 +288,7 @@ class _Plugin(object):
         process.start()
         session.plugin_process = process
         self._sessions[session_id] = session
-        logger.debug("Registered new session: {}".format(session_id))
+        logger.info("Registered new session: {}".format(session_id))
 
     def __logs_request(self, packet):
         try:


### PR DESCRIPTION
set_start_method has to be called before process Queues are instantiated.

Tested in Linux, Windows, and Docker. (Pending Mac approval)

Also make session register an info log, as that is an important message to monitor