### PR TITLE
add regression test github action

### DIFF
--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -23,17 +23,17 @@ jobs:
           $image_uri \
           python run_tests.py
 
-    docking-smina-unittests:
-      runs-on: ubuntu-latest
-      steps:
-        - uses: actions/checkout@v2
-        - name: Pull Latest docking-smina image
-          run: |
-            image_uri=public.ecr.aws/h7r1e4h2/docking-smina
-            docker pull $image_uri
-        - name: Run docking-smina tests with newest lib
-          run: |
-            docker run --rm \
-            -v $(pwd)/nanome:/opt/conda/lib/python3.7/site-packages/nanome \
-            $image_uri \
-            python -m unittest discover tests.smina
+  docking-smina-unittests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Pull Latest docking-smina image
+        run: |
+          image_uri=public.ecr.aws/h7r1e4h2/docking-smina
+          docker pull $image_uri
+      - name: Run docking-smina tests with newest lib
+        run: |
+          docker run --rm \
+          -v $(pwd)/nanome:/opt/conda/lib/python3.7/site-packages/nanome \
+          $image_uri \
+          python -m unittest discover tests.smina

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -18,7 +18,9 @@ jobs:
           python-version: 3.7.12
       - name: Run Chemical Interactions tests
         run: |
+          image_uri=public.ecr.aws/h7r1e4h2/chemical-interactions
+          docker pull $image_uri
           docker run --rm \
           -v $(pwd)/nanome:/opt/conda/lib/python3.7/site-packages/nanome \
-          public.ecr.aws/h7r1e4h2/chemical-interactions \
+          $image_uri \
           python run_tests.py

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -1,4 +1,4 @@
-name: Unittests
+name: Regression Tests
 on:
   push:
     branches:

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -8,19 +8,32 @@ on:
       - master
 
 jobs:
-  python3:
+  chemical-interactions-unittests:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install Python 3
-        uses: actions/setup-python@v1
-        with:
-          python-version: 3.7.12
-      - name: Run Chemical Interactions tests
+      - name: Pull Latest chemical-interactions image
         run: |
           image_uri=public.ecr.aws/h7r1e4h2/chemical-interactions
           docker pull $image_uri
+      - name: Run chemical-interactions tests with newest lib
+        run: |
           docker run --rm \
           -v $(pwd)/nanome:/opt/conda/lib/python3.7/site-packages/nanome \
           $image_uri \
           python run_tests.py
+
+    docking-smina-unittests:
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@v2
+        - name: Pull Latest docking-smina image
+          run: |
+            image_uri=public.ecr.aws/h7r1e4h2/docking-smina
+            docker pull $image_uri
+        - name: Run docking-smina tests with newest lib
+          run: |
+            docker run --rm \
+            -v $(pwd)/nanome:/opt/conda/lib/python3.7/site-packages/nanome \
+            $image_uri \
+            python -m unittest discover tests.smina

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -19,6 +19,6 @@ jobs:
       - name: Run Chemical Interactions tests
         run: |
           docker run --rm \
-          -v /home/mike/workspace/nanome-lib/nanome:/opt/conda/lib/python3.7/site-packages/nanome \
+          -v $(pwd)/nanome:/opt/conda/lib/python3.7/site-packages/nanome \
           public.ecr.aws/h7r1e4h2/chemical-interactions \
           python run_tests.py

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -1,0 +1,24 @@
+name: Unittests
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  python3:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Python 3
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7.12
+      - name: Run Chemical Interactions tests
+        run: |
+          docker run --rm \
+          -v /home/mike/workspace/nanome-lib/nanome:/opt/conda/lib/python3.7/site-packages/nanome \
+          public.ecr.aws/h7r1e4h2/chemical-interactions \
+          python run_tests.py

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -10,30 +10,32 @@ on:
 jobs:
   chemical-interactions-unittests:
     runs-on: ubuntu-latest
+    env:
+      IMAGE_URI: public.ecr.aws/h7r1e4h2/chemical-interactions:latest
     steps:
       - uses: actions/checkout@v2
       - name: Pull Latest chemical-interactions image
         run: |
-          image_uri=public.ecr.aws/h7r1e4h2/chemical-interactions
-          docker pull $image_uri
+          docker pull ${{ env.IMAGE_URI }}
       - name: Run chemical-interactions tests with newest lib
         run: |
           docker run --rm \
           -v $(pwd)/nanome:/opt/conda/lib/python3.7/site-packages/nanome \
-          $image_uri \
+          ${{ env.IMAGE_URI }} \
           python run_tests.py
 
   docking-smina-unittests:
     runs-on: ubuntu-latest
+    env:
+      IMAGE_URI: public.ecr.aws/h7r1e4h2/docking-smina:latest
     steps:
       - uses: actions/checkout@v2
       - name: Pull Latest docking-smina image
         run: |
-          image_uri=public.ecr.aws/h7r1e4h2/docking-smina
-          docker pull $image_uri
+          docker pull ${{ env.IMAGE_URI }}
       - name: Run docking-smina tests with newest lib
         run: |
           docker run --rm \
           -v $(pwd)/nanome:/opt/conda/lib/python3.7/site-packages/nanome \
-          $image_uri \
+          ${{ env.IMAGE_URI }} \
           python -m unittest discover tests.smina

--- a/nanome/api/plugin_instance.py
+++ b/nanome/api/plugin_instance.py
@@ -24,7 +24,6 @@ class PluginInstance(_PluginInstance):
     is_async = False
 
     def __init__(self):
-        raise Exception("Make sure regression tests fail!")
         self.room = Room()
         self.integration = Integration()
         self.files = Files(self)

--- a/nanome/api/plugin_instance.py
+++ b/nanome/api/plugin_instance.py
@@ -24,6 +24,7 @@ class PluginInstance(_PluginInstance):
     is_async = False
 
     def __init__(self):
+        raise Exception("Make sure regression tests fail!")
         self.room = Room()
         self.integration = Integration()
         self.files = Files(self)

--- a/nanome/api/plugin_instance.py
+++ b/nanome/api/plugin_instance.py
@@ -30,6 +30,9 @@ class PluginInstance(_PluginInstance):
         self.PluginListButtonType = PluginListButtonType
         self.__set_first = False
         self.__menu = Menu()  # deprecated
+        # Make sure PluginInstance singleton is set.
+        PluginInstance._instance = self
+
 
     def start(self):
         """
@@ -521,8 +524,6 @@ class PluginInstance(_PluginInstance):
             PluginInstance.__init__(self)
             # re-init child classes, so that their overrides take priority
             self.__init__()
-        # Make sure PluginInstance singleton is set.
-        PluginInstance._instance = self
 
 
 class AsyncPluginInstance(PluginInstance):


### PR DESCRIPTION
Run unittests for plugins with latest lib changes, so we catch more errors before they get merged.

Also move setting PluginInstance._instance back to __init__, so that we don't have to do this for every unittest
https://github.com/nanome-ai/plugin-chemical-interactions/blob/master/tests/test_cases.py#L36
We now ensure that __init__ is run from _setup, so this is ok