### PR TITLE
Fix remove errors

### DIFF
--- a/nanome/_internal/_structure/_chain.py
+++ b/nanome/_internal/_structure/_chain.py
@@ -17,8 +17,9 @@ class _Chain(_Base):
         residue._parent = self
 
     def _remove_residue(self, residue):
-        self._residues.remove(residue)
-        residue._parent = None
+        if residue in self._residues:
+            self._residues.remove(residue)
+            residue._parent = None
 
     def _set_residues(self, residues):
         self._residues = residues

--- a/nanome/_internal/_structure/_complex.py
+++ b/nanome/_internal/_structure/_complex.py
@@ -37,8 +37,9 @@ class _Complex(_Base):
         molecule._parent = self
 
     def _remove_molecule(self, molecule):
-        self._molecules.remove(molecule)
-        molecule._parent = None
+        if molecule in self._molecules:
+            self._molecules.remove(molecule)
+            molecule._parent = None
 
     def _set_molecules(self, molecules):
         self._molecules = molecules

--- a/nanome/_internal/_structure/_molecule.py
+++ b/nanome/_internal/_structure/_molecule.py
@@ -23,8 +23,9 @@ class _Molecule(_Base):
         chain._parent = self
 
     def _remove_chain(self, chain):
-        self._chains.remove(chain)
-        chain._parent = None
+        if chain in self._chains:
+            self._chains.remove(chain)
+            chain._parent = None
 
     def _set_chains(self, chains):
         self._chains = chains

--- a/nanome/_internal/_structure/_residue.py
+++ b/nanome/_internal/_structure/_residue.py
@@ -37,9 +37,10 @@ class _Residue(_Base):
         atom._parent = self
 
     def _remove_atom(self, atom):
-        atom.index = -1
-        self._atoms.remove(atom)
-        atom._parent = None
+        if atom in self._atoms:
+            atom.index = -1
+            self._atoms.remove(atom)
+            atom._parent = None
 
     def _add_bond(self, bond):
         bond.index = -1
@@ -47,9 +48,10 @@ class _Residue(_Base):
         bond._parent = self
 
     def _remove_bond(self, bond):
-        bond.index = -1
-        self._bonds.remove(bond)
-        bond._parent = None
+        if bond in self._bonds:
+            bond.index = -1
+            self._bonds.remove(bond)
+            bond._parent = None
 
     def _set_atoms(self, atoms):
         self._atoms = atoms

--- a/nanome/_internal/_structure/_workspace.py
+++ b/nanome/_internal/_structure/_workspace.py
@@ -19,8 +19,9 @@ class _Workspace(_Base):
         complex._parent = self
 
     def _remove_complex(self, complex):
-        self._complexes.remove(complex)
-        complex._parent = None
+        if complex in self._complexes:
+            self._complexes.remove(complex)
+            complex._parent = None
 
     @Logs.deprecated()
     def get_atom_iterator(self):


### PR DESCRIPTION
Previously, if you call `residue.remove_bond` with a `Bond` that's not in the `Residue`, it would raise an exception. This PR makes it only attempt removing if the item is actually in the list.