### PR TITLE
_Internal  Plugin refactor

### DIFF
--- a/nanome/_internal/_network/_process_network.py
+++ b/nanome/_internal/_network/_process_network.py
@@ -13,6 +13,19 @@ class _ProcessNetwork(object):
 
     _instance = None
 
+    def __init__(self, plugin, session_id, queue_net_in, queue_net_out, serializer, plugin_id, version_table):
+        self._plugin = plugin
+        self._session_id = session_id
+        self._queue_net_in = queue_net_in
+        self._queue_net_out = queue_net_out
+        self._serializer = serializer
+        self._serializer._plugin_id = plugin_id
+        self._plugin_id = plugin_id
+        self._command_id = 0
+        self.__version_table = version_table
+        _CachedImageSerializer.session = session_id
+        _ProcessNetwork._instance = self
+
     def _on_run(self):
         Logs.message("on_run called")
         self._plugin.on_run()
@@ -92,18 +105,3 @@ class _ProcessNetwork(object):
                 return True
             callback(self, received_object, request_id)
         return True
-
-    def __init__(self, plugin, session_id, queue_net_in, queue_net_out, serializer, plugin_id, version_table):
-        self._plugin = plugin
-        self._session_id = session_id
-        self._queue_net_in = queue_net_in
-        self._queue_net_out = queue_net_out
-        self._serializer = serializer
-        self._serializer._plugin_id = plugin_id
-        self._plugin_id = plugin_id
-        self._command_id = 0
-        self.__version_table = version_table
-
-        _CachedImageSerializer.session = session_id
-
-        _ProcessNetwork._instance = self

--- a/nanome/_internal/_plugin.py
+++ b/nanome/_internal/_plugin.py
@@ -1,5 +1,6 @@
 from nanome._internal import _network as Network
 from nanome._internal._process import _ProcessManager
+from nanome._internal._network import _ProcessNetwork
 from nanome._internal._network._commands._callbacks._commands_enums import _Hashes
 from nanome._internal._network._serialization._serializer import Serializer
 from nanome._internal._util._serializers import _TypeSerializer
@@ -319,19 +320,12 @@ class _Plugin(object):
     @classmethod
     def _launch_plugin(cls, plugin_class, session_id, queue_net_in, queue_net_out, pipe_proc, log_pipe_conn, serializer, plugin_id, version_table, original_version_table, custom_data, permissions):
         plugin_instance = plugin_class()
+        process_network = _ProcessNetwork(plugin_instance, session_id, queue_net_in, queue_net_out, serializer, plugin_id, version_table)
         plugin_instance._setup(
-            session_id, queue_net_in, queue_net_out, pipe_proc, log_pipe_conn,
-            serializer, plugin_id, version_table, original_version_table, custom_data,
-            permissions)
+            session_id, process_network, pipe_proc, log_pipe_conn, original_version_table, custom_data, permissions)
         LogsManager.configure_child_process(plugin_instance)
         logger.debug("Starting plugin")
         plugin_instance._run()
-
-    @classmethod
-    def _launch_plugin_profile(cls, plugin_class, session_id, pipe_net, pipe_proc, serializer, plugin_id, version_table, original_version_table, verbose, custom_data, permissions):
-        cProfile.runctx('_Plugin._launch_plugin(plugin_class, session_id, pipe_net, pipe_proc, serializer, '
-                        'plugin_id, version_table, original_version_table, verbose, custom_data,'
-                        'permissions)', globals(), locals(), 'profile.out')
 
     def __init__(self, name, description, tags=None, has_advanced=False, permissions=None, integrations=None):
         tags = tags or []

--- a/nanome/_internal/_plugin.py
+++ b/nanome/_internal/_plugin.py
@@ -92,7 +92,7 @@ class _Plugin(object):
         self._loop()
 
     @classmethod
-    def run_plugin_instance(
+    def _run_plugin_instance(
         cls, plugin_instance_class, session_id, queue_net_in, queue_net_out,
         pipe_proc, log_pipe_conn, serializer, plugin_id, version_table,
             original_version_table, custom_data, permissions):
@@ -353,7 +353,7 @@ class _Plugin(object):
         permissions = self._description["permissions"]
         log_pipe_conn = self._logs_manager.child_pipe_conn
         process = Process(
-            target=self.run_plugin_instance,
+            target=self._run_plugin_instance,
             args=(
                 self._plugin_class, session_id, main_conn_net, process_conn_net,
                 process_conn_proc, log_pipe_conn, self.__serializer, self._plugin_id,

--- a/nanome/_internal/_plugin.py
+++ b/nanome/_internal/_plugin.py
@@ -140,9 +140,9 @@ class _Plugin(object):
             return None
 
     def _on_packet_received(self, packet):
+        """When packet received, identify Packet type, and call appropriate function."""
         if packet.packet_type == Network._Packet.packet_type_message_to_plugin:
             session_id = packet.session_id
-
             # Always look if we're trying to register a session
             #   Fix 5/27/2021 - Jeremie: We need to always check for session registration in order to fix timeout issues
             #   When NTS forces disconnection because of plugin list change, session_id still exists in self._sessions,
@@ -246,6 +246,7 @@ class _Plugin(object):
                 break
 
     def __connect(self):
+        """Create network Connection to NTS, and start listening for packets."""
         self._network = Network._NetInstance(self, self.__class__._on_packet_received)
         if self._network.connect(self._host, self._port):
             if self._plugin_id >= 0:
@@ -335,6 +336,10 @@ class _Plugin(object):
         sys.exit(0)
 
     def __on_client_connection(self, session_id, version_table):
+        self._start_session_process(session_id, version_table)
+
+    def _start_session_process(self, session_id, version_table):
+        """Setup Pipes and networking for Plugininstance, run session process."""
         if session_id in self._sessions:  # If session_id already exists, close it first ()
             logger.info("Closing session ID {} because a new session connected with the same ID".format(session_id))
             self._sessions[session_id].signal_and_close_pipes()

--- a/nanome/_internal/_plugin.py
+++ b/nanome/_internal/_plugin.py
@@ -97,7 +97,7 @@ class _Plugin(object):
         pipe_proc, log_pipe_conn, serializer, plugin_id, version_table,
             original_version_table, custom_data, permissions):
         """When user activates a plugin, this function is run to begin the new process.
-        
+
         :arg plugin_instance_class: The Plugininstance class to be instantiated.
         :arg session_id: The session ID registered with NTS.
         :arg queue_net_in: The network input queue.

--- a/nanome/_internal/_plugin_instance.py
+++ b/nanome/_internal/_plugin_instance.py
@@ -1,6 +1,6 @@
 import nanome
 from nanome.util import Logs
-from nanome._internal._network import _ProcessNetwork, _Packet
+from nanome._internal._network import _Packet
 from nanome._internal._process import _ProcessManagerInstance
 from nanome._internal._network._commands._callbacks import _Messages
 from nanome._internal._network._commands._callbacks._commands_enums import _Hashes
@@ -27,7 +27,8 @@ class _PluginInstance(object):
     __complex_updated_callbacks = dict()
     __selection_changed_callbacks = dict()
 
-    def _setup(self, session_id, queue_net_in, queue_net_out, proc_pipe, log_pipe_conn, serializer, plugin_id, version_table, original_version_table, custom_data, permissions):
+    def _setup(
+        self, session_id, process_network, proc_pipe, log_pipe_conn, original_version_table, custom_data, permissions):
         self._menus = {}
         self._run_text = "Run"
         self._run_usable = True
@@ -35,8 +36,8 @@ class _PluginInstance(object):
         self._advanced_settings_usable = True
         self._custom_data = custom_data
         self._permissions = permissions
-
-        self._network = _ProcessNetwork(self, session_id, queue_net_in, queue_net_out, serializer, plugin_id, version_table)
+        
+        self._network = process_network
         self._process_manager = _ProcessManagerInstance(proc_pipe)
         self._log_pipe_conn = log_pipe_conn
         self._network._send_connect(_Messages.connect, [_Packet._compression_type(), original_version_table])

--- a/nanome/_internal/_plugin_instance.py
+++ b/nanome/_internal/_plugin_instance.py
@@ -28,7 +28,8 @@ class _PluginInstance(object):
     __selection_changed_callbacks = dict()
 
     def _setup(
-        self, session_id, process_network, proc_pipe, log_pipe_conn, original_version_table, custom_data, permissions):
+        self, session_id, process_network, proc_pipe, log_pipe_conn,
+            original_version_table, custom_data, permissions):
         self._menus = {}
         self._run_text = "Run"
         self._run_usable = True

--- a/nanome/_internal/_plugin_instance.py
+++ b/nanome/_internal/_plugin_instance.py
@@ -37,7 +37,7 @@ class _PluginInstance(object):
         self._advanced_settings_usable = True
         self._custom_data = custom_data
         self._permissions = permissions
-        
+
         self._network = process_network
         self._process_manager = _ProcessManagerInstance(proc_pipe)
         self._log_pipe_conn = log_pipe_conn

--- a/nanome/api/plugin_instance.py
+++ b/nanome/api/plugin_instance.py
@@ -506,14 +506,11 @@ class PluginInstance(_PluginInstance):
         self.create_writing_stream(atom_indices_list, stream_type, callback)
 
     def _setup(
-        self, session_id, queue_net_in, queue_net_out, proc_pipe, log_pipe_conn,
-        serializer, plugin_id, version_table, original_version_table, custom_data,
-            permissions):
+            self, session_id, process_network, proc_pipe, log_pipe_conn,
+            original_version_table, custom_data, permissions):
         super(PluginInstance, self)._setup(
-            session_id, queue_net_in, queue_net_out, proc_pipe, log_pipe_conn,
-            serializer, plugin_id, version_table, original_version_table, custom_data,
-            permissions)
-
+            session_id, process_network, proc_pipe, log_pipe_conn,
+            original_version_table, custom_data, permissions)
         # We assume that a scientist creating their own plugin should not have to remember
         # to call super()
         # _setup is called by the Plugin during the process launch. If init hasn't been properly run,

--- a/testing/plugin_instance_tests.py
+++ b/testing/plugin_instance_tests.py
@@ -21,12 +21,13 @@ class PluginInstanceTestCase(unittest.TestCase):
         self.custom_data = {'a': 'b'}
         self.plugin_instance = PluginInstance()
         # Mock args that are passed to setup plugin instance networking
-        session_id = queue_net_in = queue_net_out = proc_pipe = log_pipe_conn = \
-            serializer = plugin_id = version_table = original_version_table = \
-            permissions = MagicMock()
+        session_id = process_network = proc_pipe = log_pipe_conn = \
+            original_version_table = permissions = MagicMock()
+        
         self.plugin_instance._setup(
-            session_id, queue_net_in, queue_net_out, proc_pipe, log_pipe_conn, serializer,
-            plugin_id, version_table, original_version_table, self.custom_data, permissions)
+            session_id, process_network, proc_pipe, log_pipe_conn,
+            original_version_table, self.custom_data, permissions
+            )
         self.plugin_instance._network = MagicMock()
 
     def test_on_advanced_settings(self):

--- a/testing/plugin_instance_tests.py
+++ b/testing/plugin_instance_tests.py
@@ -23,11 +23,11 @@ class PluginInstanceTestCase(unittest.TestCase):
         # Mock args that are passed to setup plugin instance networking
         session_id = process_network = proc_pipe = log_pipe_conn = \
             original_version_table = permissions = MagicMock()
-        
+
         self.plugin_instance._setup(
             session_id, process_network, proc_pipe, log_pipe_conn,
             original_version_table, self.custom_data, permissions
-            )
+        )
         self.plugin_instance._network = MagicMock()
 
     def test_on_advanced_settings(self):


### PR DESCRIPTION
- rename _launch_plugin to run_plugin_instance
- Create ProcessNetwork before PluginInstance._setup, which reduces the parameter count
- Move __init__s to the top of the class
- Add some docstrings
- Reduce some line-lengths