### PR TITLE
Mostly Cosmetic Process refactor

### DIFF
--- a/nanome/_internal/_macro/_macro.py
+++ b/nanome/_internal/_macro/_macro.py
@@ -1,7 +1,7 @@
 import nanome
 import string
 import random
-from nanome._internal._network import NetworkProcess
+from nanome._internal._network import PluginNetwork
 from nanome._internal._network._commands._callbacks import _Messages
 
 
@@ -18,22 +18,22 @@ class _Macro(object):
         return cls()
 
     def _save(self, all_users=False):
-        NetworkProcess._send(_Messages.save_macro, (self, all_users, _Macro._plugin_identifier), False)
+        PluginNetwork._send(_Messages.save_macro, (self, all_users, _Macro._plugin_identifier), False)
 
     def _run(self, callback=None):
         expects_response = callback is not None or nanome.PluginInstance._instance.is_async
-        id = NetworkProcess._send(_Messages.run_macro, self, expects_response)
+        id = PluginNetwork._send(_Messages.run_macro, self, expects_response)
         return nanome.PluginInstance._save_callback(id, callback)
 
     def _delete(self, all_users=False):
-        NetworkProcess._send(_Messages.delete_macro, (self, all_users, _Macro._plugin_identifier), False)
+        PluginNetwork._send(_Messages.delete_macro, (self, all_users, _Macro._plugin_identifier), False)
 
     @classmethod
     def _stop(cls):
-        NetworkProcess._send(_Messages.stop_macro, None, False)
+        PluginNetwork._send(_Messages.stop_macro, None, False)
 
     @classmethod
     def _get_live(cls, callback=None):
         expects_response = callback is not None or nanome.PluginInstance._instance.is_async
-        id = NetworkProcess._send(_Messages.get_macros, _Macro._plugin_identifier, expects_response)
+        id = PluginNetwork._send(_Messages.get_macros, _Macro._plugin_identifier, expects_response)
         return nanome.PluginInstance._save_callback(id, callback)

--- a/nanome/_internal/_macro/_macro.py
+++ b/nanome/_internal/_macro/_macro.py
@@ -1,7 +1,7 @@
 import nanome
 import string
 import random
-from nanome._internal._network import _ProcessNetwork
+from nanome._internal._network import NetworkProcess
 from nanome._internal._network._commands._callbacks import _Messages
 
 
@@ -18,22 +18,22 @@ class _Macro(object):
         return cls()
 
     def _save(self, all_users=False):
-        _ProcessNetwork._send(_Messages.save_macro, (self, all_users, _Macro._plugin_identifier), False)
+        NetworkProcess._send(_Messages.save_macro, (self, all_users, _Macro._plugin_identifier), False)
 
     def _run(self, callback=None):
         expects_response = callback is not None or nanome.PluginInstance._instance.is_async
-        id = _ProcessNetwork._send(_Messages.run_macro, self, expects_response)
+        id = NetworkProcess._send(_Messages.run_macro, self, expects_response)
         return nanome.PluginInstance._save_callback(id, callback)
 
     def _delete(self, all_users=False):
-        _ProcessNetwork._send(_Messages.delete_macro, (self, all_users, _Macro._plugin_identifier), False)
+        NetworkProcess._send(_Messages.delete_macro, (self, all_users, _Macro._plugin_identifier), False)
 
     @classmethod
     def _stop(cls):
-        _ProcessNetwork._send(_Messages.stop_macro, None, False)
+        NetworkProcess._send(_Messages.stop_macro, None, False)
 
     @classmethod
     def _get_live(cls, callback=None):
         expects_response = callback is not None or nanome.PluginInstance._instance.is_async
-        id = _ProcessNetwork._send(_Messages.get_macros, _Macro._plugin_identifier, expects_response)
+        id = NetworkProcess._send(_Messages.get_macros, _Macro._plugin_identifier, expects_response)
         return nanome.PluginInstance._save_callback(id, callback)

--- a/nanome/_internal/_network/__init__.py
+++ b/nanome/_internal/_network/__init__.py
@@ -3,7 +3,7 @@ from . import *
 from ._data import _Data
 from ._packet import _Packet
 from ._net_instance import _NetInstance
-from ._process_network import _ProcessNetwork
+from ._process_network import NetworkProcess
 from ._session import _Session
 # folders
 from . import _serialization

--- a/nanome/_internal/_network/__init__.py
+++ b/nanome/_internal/_network/__init__.py
@@ -3,7 +3,7 @@ from . import *
 from ._data import _Data
 from ._packet import _Packet
 from ._net_instance import _NetInstance
-from ._process_network import NetworkProcess
+from ._process_network import PluginNetwork
 from ._session import _Session
 # folders
 from . import _serialization

--- a/nanome/_internal/_network/_process_network.py
+++ b/nanome/_internal/_network/_process_network.py
@@ -9,9 +9,25 @@ stop_bytes = bytearray("CLOSEPIPE", "utf-8")
 # Plugin networking class, used from the instance processes
 
 
-class _ProcessNetwork(object):
+class NetworkProcess(object):
 
     _instance = None
+    
+    def __init__(self, plugin, session_id, queue_net_in, queue_net_out, serializer, plugin_id, version_table):
+        self._plugin = plugin
+        self._session_id = session_id
+        self._queue_net_in = queue_net_in
+        self._queue_net_out = queue_net_out
+        self._serializer = serializer
+        self._serializer._plugin_id = plugin_id
+        self._plugin_id = plugin_id
+        self._command_id = 0
+        self.__version_table = version_table
+
+        _CachedImageSerializer.session = session_id
+
+        NetworkProcess._instance = self
+
 
     def _on_run(self):
         Logs.message("on_run called")
@@ -92,18 +108,3 @@ class _ProcessNetwork(object):
                 return True
             callback(self, received_object, request_id)
         return True
-
-    def __init__(self, plugin, session_id, queue_net_in, queue_net_out, serializer, plugin_id, version_table):
-        self._plugin = plugin
-        self._session_id = session_id
-        self._queue_net_in = queue_net_in
-        self._queue_net_out = queue_net_out
-        self._serializer = serializer
-        self._serializer._plugin_id = plugin_id
-        self._plugin_id = plugin_id
-        self._command_id = 0
-        self.__version_table = version_table
-
-        _CachedImageSerializer.session = session_id
-
-        _ProcessNetwork._instance = self

--- a/nanome/_internal/_network/_process_network.py
+++ b/nanome/_internal/_network/_process_network.py
@@ -9,7 +9,7 @@ stop_bytes = bytearray("CLOSEPIPE", "utf-8")
 # Plugin networking class, used from the instance processes
 
 
-class NetworkProcess(object):
+class PluginNetwork(object):
 
     _instance = None
 
@@ -26,7 +26,7 @@ class NetworkProcess(object):
 
         _CachedImageSerializer.session = session_id
 
-        NetworkProcess._instance = self
+        PluginNetwork._instance = self
 
     def _on_run(self):
         Logs.message("on_run called")

--- a/nanome/_internal/_network/_process_network.py
+++ b/nanome/_internal/_network/_process_network.py
@@ -12,7 +12,7 @@ stop_bytes = bytearray("CLOSEPIPE", "utf-8")
 class NetworkProcess(object):
 
     _instance = None
-    
+
     def __init__(self, plugin, session_id, queue_net_in, queue_net_out, serializer, plugin_id, version_table):
         self._plugin = plugin
         self._session_id = session_id
@@ -27,7 +27,6 @@ class NetworkProcess(object):
         _CachedImageSerializer.session = session_id
 
         NetworkProcess._instance = self
-
 
     def _on_run(self):
         Logs.message("on_run called")

--- a/nanome/_internal/_plugin.py
+++ b/nanome/_internal/_plugin.py
@@ -1,5 +1,5 @@
 from nanome._internal import _network as Network
-from nanome._internal._process import _ProcessManager
+from nanome._internal._process import ProcessManager
 from nanome._internal._network._commands._callbacks._commands_enums import _Hashes
 from nanome._internal._network._serialization._serializer import Serializer
 from nanome._internal._util._serializers import _TypeSerializer
@@ -49,7 +49,7 @@ class _Plugin(object):
             self._pre_run()
 
         self._description['auth'] = self.__read_key()
-        self._process_manager = _ProcessManager()
+        self._process_manager = ProcessManager()
 
         self.__reconnect_attempt = 0
         self.__connect()

--- a/nanome/_internal/_plugin.py
+++ b/nanome/_internal/_plugin.py
@@ -241,7 +241,7 @@ class _Plugin(object):
                 for id in to_remove:
                     self._sessions[id]._send_disconnection_message(self._plugin_id)
                     del self._sessions[id]
-                self._process_manager._update()
+                self._process_manager.update()
         except KeyboardInterrupt:
             self.__exit()
 

--- a/nanome/_internal/_plugin_instance.py
+++ b/nanome/_internal/_plugin_instance.py
@@ -1,7 +1,7 @@
 import nanome
 from nanome.util import Logs
 from nanome._internal._network import _ProcessNetwork, _Packet
-from nanome._internal._process import _ProcessManagerInstance
+from nanome._internal._process import ProcessManagerInstance
 from nanome._internal._network._commands._callbacks import _Messages
 from nanome._internal._network._commands._callbacks._commands_enums import _Hashes
 
@@ -37,7 +37,7 @@ class _PluginInstance(object):
         self._permissions = permissions
 
         self._network = _ProcessNetwork(self, session_id, queue_net_in, queue_net_out, serializer, plugin_id, version_table)
-        self._process_manager = _ProcessManagerInstance(proc_pipe)
+        self._process_manager = ProcessManagerInstance(proc_pipe)
         self._log_pipe_conn = log_pipe_conn
         self._network._send_connect(_Messages.connect, [_Packet._compression_type(), original_version_table])
         Logs.debug("Plugin constructed for session", session_id)

--- a/nanome/_internal/_plugin_instance.py
+++ b/nanome/_internal/_plugin_instance.py
@@ -1,6 +1,6 @@
 import nanome
 from nanome.util import Logs
-from nanome._internal._network import _ProcessNetwork, _Packet
+from nanome._internal._network import NetworkProcess, _Packet
 from nanome._internal._process import ProcessManagerInstance
 from nanome._internal._network._commands._callbacks import _Messages
 from nanome._internal._network._commands._callbacks._commands_enums import _Hashes
@@ -36,7 +36,7 @@ class _PluginInstance(object):
         self._custom_data = custom_data
         self._permissions = permissions
 
-        self._network = _ProcessNetwork(self, session_id, queue_net_in, queue_net_out, serializer, plugin_id, version_table)
+        self._network = NetworkProcess(self, session_id, queue_net_in, queue_net_out, serializer, plugin_id, version_table)
         self._process_manager = ProcessManagerInstance(proc_pipe)
         self._log_pipe_conn = log_pipe_conn
         self._network._send_connect(_Messages.connect, [_Packet._compression_type(), original_version_table])

--- a/nanome/_internal/_plugin_instance.py
+++ b/nanome/_internal/_plugin_instance.py
@@ -1,6 +1,6 @@
 import nanome
 from nanome.util import Logs
-from nanome._internal._network import NetworkProcess, _Packet
+from nanome._internal._network import PluginNetwork, _Packet
 from nanome._internal._process import ProcessManagerInstance
 from nanome._internal._network._commands._callbacks import _Messages
 from nanome._internal._network._commands._callbacks._commands_enums import _Hashes
@@ -36,7 +36,7 @@ class _PluginInstance(object):
         self._custom_data = custom_data
         self._permissions = permissions
 
-        self._network = NetworkProcess(self, session_id, queue_net_in, queue_net_out, serializer, plugin_id, version_table)
+        self._network = PluginNetwork(self, session_id, queue_net_in, queue_net_out, serializer, plugin_id, version_table)
         self._process_manager = ProcessManagerInstance(proc_pipe)
         self._log_pipe_conn = log_pipe_conn
         self._network._send_connect(_Messages.connect, [_Packet._compression_type(), original_version_table])

--- a/nanome/_internal/_process/__init__.py
+++ b/nanome/_internal/_process/__init__.py
@@ -1,7 +1,7 @@
 from . import *
 # classes
-from ._process_entry import _ProcessEntry
-from ._process_manager import _ProcessManager
-from ._process_manager_instance import _ProcessManagerInstance
+from ._process_entry import ProcessEntry
+from ._process_manager import ProcessManager
+from ._process_manager_instance import ProcessManagerInstance
 from ._bonding import _Bonding
 from ._dssp import _Dssp

--- a/nanome/_internal/_process/_process_entry.py
+++ b/nanome/_internal/_process/_process_entry.py
@@ -1,9 +1,9 @@
-class _ProcessEntry():
+class ProcessEntry():
     _current_process_id = 0
 
     def __init__(self, request, session):
-        request.id = _ProcessEntry._current_process_id
-        _ProcessEntry._current_process_id += 1
+        request.id = ProcessEntry._current_process_id
+        ProcessEntry._current_process_id += 1
         self.__request = request
         self.__session = session
         self.__process = None

--- a/nanome/_internal/_process/_process_manager.py
+++ b/nanome/_internal/_process/_process_manager.py
@@ -137,7 +137,7 @@ class ProcessManager():
         if timeout and time.time() - entry.start_time > timeout:
             entry.process.kill()
             message = "Process timed out after {} seconds".format(timeout)
-            entry.send(_ProcessManager._DataType.error, [message])
+            entry.send(ProcessManager.DataType.error, [message])
 
         # Check if process finished
         exit_code = entry.process.poll()

--- a/nanome/_internal/_process/_process_manager.py
+++ b/nanome/_internal/_process/_process_manager.py
@@ -188,12 +188,13 @@ class ProcessManager():
 
     def received_request(self, data, session):
         type = data[0]
+        process_request = data[1]
         if type == ProcessManager.CommandType.start:
-            request = data[1]
+            request = process_request
             entry = ProcessEntry(request, session)
             self.__pending.append(entry)
             session.send_process_data([ProcessManager.DataType.queued, request])
         elif type == ProcessManager.CommandType.stop:
-            self.__stop_process(data[1])
+            self.__stop_process(process_request)
         else:
             Logs.error("Received unknown process command type")

--- a/nanome/_internal/_process/_process_manager.py
+++ b/nanome/_internal/_process/_process_manager.py
@@ -136,8 +136,6 @@ class ProcessManager():
         timeout = getattr(entry.request, 'timeout')
         if timeout and time.time() - entry.start_time > timeout:
             entry.process.kill()
-            message = "Process timed out after {} seconds".format(timeout)
-            entry.send(ProcessManager.DataType.error, [message])
 
         # Check if process finished
         exit_code = entry.process.poll()

--- a/nanome/_internal/_process/_process_manager.py
+++ b/nanome/_internal/_process/_process_manager.py
@@ -37,7 +37,7 @@ class ProcessManager():
         self.__pending = deque()
         self.__running = []
 
-    def _update(self):
+    def update(self):
         try:
             for i in range(len(self.__running) - 1, -1, -1):
                 proc = self.__running[i]

--- a/nanome/_internal/_process/_process_manager.py
+++ b/nanome/_internal/_process/_process_manager.py
@@ -183,7 +183,7 @@ class ProcessManager():
             self.__pending.remove(entry)
 
         for entry in running:
-            entry.process.kill()
+            entry.process.terminate()
             self.__running.remove(entry)
 
     def received_request(self, data, session):

--- a/nanome/_internal/_process/_process_manager.py
+++ b/nanome/_internal/_process/_process_manager.py
@@ -183,7 +183,7 @@ class ProcessManager():
             self.__pending.remove(entry)
 
         for entry in running:
-            entry.process.terminate()
+            entry.process.kill()
             self.__running.remove(entry)
 
     def received_request(self, data, session):

--- a/nanome/_internal/_process/_process_manager.py
+++ b/nanome/_internal/_process/_process_manager.py
@@ -27,7 +27,7 @@ class ProcessManager():
         output = auto()
         done = auto()
 
-    class _CommandType(IntEnum):
+    class CommandType(IntEnum):
         start = auto()
         stop = auto()
 

--- a/nanome/_internal/_process/_process_manager.py
+++ b/nanome/_internal/_process/_process_manager.py
@@ -11,15 +11,15 @@ try:
 except ImportError:
     from Queue import Queue, Empty  # python 2.x
 
-from nanome._internal._process import _ProcessEntry
+from nanome._internal._process import ProcessEntry
 from nanome.util import Logs, IntEnum, auto
 
 POSIX = 'posix' in sys.builtin_module_names
 
 
-class _ProcessManager():
+class ProcessManager():
 
-    class _DataType(IntEnum):
+    class DataType(IntEnum):
         queued = auto()
         position_changed = auto()
         starting = auto()
@@ -44,7 +44,7 @@ class _ProcessManager():
                 if self.__update_process(proc) == False:
                     del self.__running[i]
 
-            spawn_count = min(_ProcessManager._max_process_count - len(self.__running), len(self.__pending))
+            spawn_count = min(ProcessManager._max_process_count - len(self.__running), len(self.__pending))
             if spawn_count > 0:
                 while spawn_count > 0:
                     self.__start_process()
@@ -52,14 +52,14 @@ class _ProcessManager():
 
                 count_before_exec = 1
                 for entry in self.__pending:
-                    entry.send(_ProcessManager._DataType.position_changed, [count_before_exec])
+                    entry.send(ProcessManager.DataType.position_changed, [count_before_exec])
                     count_before_exec += 1
         except:
             Logs.error("Exception in process manager update:\n", traceback.format_exc())
 
     def __start_process(self):
         entry = self.__pending.popleft()
-        entry.send(_ProcessManager._DataType.starting, [])
+        entry.send(ProcessManager.DataType.starting, [])
         request = entry.request
         args = [request.executable_path] + request.args
         has_text = entry.output_text
@@ -97,7 +97,7 @@ class _ProcessManager():
             Logs.message(msg, extra=extra)
         except:
             Logs.error("Couldn't execute process", exec_path, "Please check if executable is present and has permissions:\n", traceback.format_exc())
-            entry.send(_ProcessManager._DataType.done, [-1])
+            entry.send(ProcessManager.DataType.done, [-1])
             return
         entry.stdout_queue = Queue()
         entry.stderr_queue = Queue()
@@ -127,10 +127,10 @@ class _ProcessManager():
             pass
 
         if error:
-            entry.send(_ProcessManager._DataType.error, [error])
+            entry.send(ProcessManager.DataType.error, [error])
 
         if output:
-            entry.send(_ProcessManager._DataType.output, [output])
+            entry.send(ProcessManager.DataType.output, [output])
 
         # Check if timeout occurred
         timeout = getattr(entry.request, 'timeout')
@@ -165,7 +165,7 @@ class _ProcessManager():
                 Logs.message(message, extra=log_extra)
             else:
                 Logs.warning(message, extra=log_extra)
-            entry.send(_ProcessManager._DataType.done, [exit_code])
+            entry.send(ProcessManager.DataType.done, [exit_code])
             return False
         return True
 
@@ -188,13 +188,12 @@ class _ProcessManager():
 
     def received_request(self, data, session):
         type = data[0]
-        process_request = data[1]
-        if type == _ProcessManager._CommandType.start:
-            request = process_request
-            entry = _ProcessEntry(request, session)
+        if type == ProcessManager._CommandType.start:
+            request = data[1]
+            entry = ProcessEntry(request, session)
             self.__pending.append(entry)
-            session.send_process_data([_ProcessManager._DataType.queued, request])
-        elif type == _ProcessManager._CommandType.stop:
-            self.__stop_process(process_request)
+            session.send_process_data([ProcessManager.DataType.queued, request])
+        elif type == ProcessManager._CommandType.stop:
+            self.__stop_process(data[1])
         else:
             Logs.error("Received unknown process command type")

--- a/nanome/_internal/_process/_process_manager.py
+++ b/nanome/_internal/_process/_process_manager.py
@@ -188,12 +188,12 @@ class ProcessManager():
 
     def received_request(self, data, session):
         type = data[0]
-        if type == ProcessManager._CommandType.start:
+        if type == ProcessManager.CommandType.start:
             request = data[1]
             entry = ProcessEntry(request, session)
             self.__pending.append(entry)
             session.send_process_data([ProcessManager.DataType.queued, request])
-        elif type == ProcessManager._CommandType.stop:
+        elif type == ProcessManager.CommandType.stop:
             self.__stop_process(data[1])
         else:
             Logs.error("Received unknown process command type")

--- a/nanome/_internal/_process/_process_manager_instance.py
+++ b/nanome/_internal/_process/_process_manager_instance.py
@@ -20,7 +20,7 @@ class ProcessManagerInstance():
         self.send(ProcessManager.CommandType.stop, process.id)
 
     def send(self, type, data):
-        from nanome._internal._util import ProcData
+        from nanome._internal._util._proc_data import ProcData
         to_send = ProcData()
         to_send._data = [type, data]
         self.__pipe.send(to_send)

--- a/nanome/_internal/_process/_process_manager_instance.py
+++ b/nanome/_internal/_process/_process_manager_instance.py
@@ -62,7 +62,7 @@ class ProcessManagerInstance():
             self.__processes[process_request].on_output(data[2])
         else:
             Logs.error("Received unknown process data type")
-    
+
     def _close(self):
         try:
             self.__pipe.close()

--- a/nanome/_internal/_process/_process_manager_instance.py
+++ b/nanome/_internal/_process/_process_manager_instance.py
@@ -17,7 +17,7 @@ class ProcessManagerInstance():
         self.send(ProcessManager.CommandType.start, request)
 
     def stop_process(self, process):
-        self.send(ProcessManager.CommandType.stop, process._id)
+        self.send(ProcessManager.CommandType.stop, process.id)
 
     def send(self, type, data):
         from nanome._internal._util import ProcData
@@ -46,7 +46,7 @@ class ProcessManagerInstance():
         if type == ProcessManager.DataType.queued:
             process = self.__pending_start.popleft()
             process.on_queued()
-            process._id = data[1].id
+            process.id = data[1].id
             self.__processes[data[1].id] = process
         elif type == ProcessManager.DataType.position_changed:
             self.__processes[data[1]].on_queue_position_change(data[2])

--- a/nanome/_internal/_room.py
+++ b/nanome/_internal/_room.py
@@ -1,5 +1,5 @@
 import nanome
-from nanome._internal._network import _ProcessNetwork
+from nanome._internal._network import NetworkProcess
 from nanome._internal._network._commands._callbacks import _Messages
 
 
@@ -10,4 +10,4 @@ class _Room():
         pass
 
     def _set_skybox(self, skybox):
-        _ProcessNetwork._send(_Messages.set_skybox, skybox, False)
+        NetworkProcess._send(_Messages.set_skybox, skybox, False)

--- a/nanome/_internal/_room.py
+++ b/nanome/_internal/_room.py
@@ -1,5 +1,5 @@
 import nanome
-from nanome._internal._network import NetworkProcess
+from nanome._internal._network import PluginNetwork
 from nanome._internal._network._commands._callbacks import _Messages
 
 
@@ -10,4 +10,4 @@ class _Room():
         pass
 
     def _set_skybox(self, skybox):
-        NetworkProcess._send(_Messages.set_skybox, skybox, False)
+        PluginNetwork._send(_Messages.set_skybox, skybox, False)

--- a/nanome/_internal/_shapes/_shape.py
+++ b/nanome/_internal/_shapes/_shape.py
@@ -23,7 +23,7 @@ class _Shape(object):
             if done_callback is not None:
                 done_callback(result)
 
-        id = nanome._internal._network._ProcessNetwork._instance._send(nanome._internal._network._commands._callbacks._Messages.set_shape, [self], True)
+        id = nanome._internal._network.NetworkProcess._instance._send(nanome._internal._network._commands._callbacks._Messages.set_shape, [self], True)
         result = nanome.PluginInstance._save_callback(id, set_callback if done_callback else None)
         if done_callback is None and nanome.PluginInstance._instance.is_async:
             result.real_set_result = result.set_result
@@ -44,7 +44,7 @@ class _Shape(object):
             if done_callback is not None:
                 done_callback(results)
 
-        id = nanome._internal._network._ProcessNetwork._instance._send(nanome._internal._network._commands._callbacks._Messages.set_shape, shapes, True)
+        id = nanome._internal._network.NetworkProcess._instance._send(nanome._internal._network._commands._callbacks._Messages.set_shape, shapes, True)
         result = nanome.PluginInstance._save_callback(id, set_callback if done_callback else None)
         if done_callback is None and nanome.PluginInstance._instance.is_async:
             result.real_set_result = result.set_result
@@ -57,7 +57,7 @@ class _Shape(object):
             if done_callback is not None:
                 done_callback(indices)
 
-        id = nanome._internal._network._ProcessNetwork._instance._send(nanome._internal._network._commands._callbacks._Messages.delete_shape, [self._index], True)
+        id = nanome._internal._network.NetworkProcess._instance._send(nanome._internal._network._commands._callbacks._Messages.delete_shape, [self._index], True)
         result = nanome.PluginInstance._save_callback(id, set_callback if done_callback else None)
         if done_callback is None and nanome.PluginInstance._instance.is_async:
             result.real_set_result = result.set_result
@@ -72,7 +72,7 @@ class _Shape(object):
                 done_callback(indices)
 
         indices = [x._index for x in shapes]
-        id = nanome._internal._network._ProcessNetwork._instance._send(nanome._internal._network._commands._callbacks._Messages.delete_shape, indices, True)
+        id = nanome._internal._network.NetworkProcess._instance._send(nanome._internal._network._commands._callbacks._Messages.delete_shape, indices, True)
         result = nanome.PluginInstance._save_callback(id, set_callback if done_callback else None)
         if done_callback is None and nanome.PluginInstance._instance.is_async:
             result.real_set_result = result.set_result

--- a/nanome/_internal/_shapes/_shape.py
+++ b/nanome/_internal/_shapes/_shape.py
@@ -23,7 +23,7 @@ class _Shape(object):
             if done_callback is not None:
                 done_callback(result)
 
-        id = nanome._internal._network.NetworkProcess._instance._send(nanome._internal._network._commands._callbacks._Messages.set_shape, [self], True)
+        id = nanome._internal._network.PluginNetwork._instance._send(nanome._internal._network._commands._callbacks._Messages.set_shape, [self], True)
         result = nanome.PluginInstance._save_callback(id, set_callback if done_callback else None)
         if done_callback is None and nanome.PluginInstance._instance.is_async:
             result.real_set_result = result.set_result
@@ -44,7 +44,7 @@ class _Shape(object):
             if done_callback is not None:
                 done_callback(results)
 
-        id = nanome._internal._network.NetworkProcess._instance._send(nanome._internal._network._commands._callbacks._Messages.set_shape, shapes, True)
+        id = nanome._internal._network.PluginNetwork._instance._send(nanome._internal._network._commands._callbacks._Messages.set_shape, shapes, True)
         result = nanome.PluginInstance._save_callback(id, set_callback if done_callback else None)
         if done_callback is None and nanome.PluginInstance._instance.is_async:
             result.real_set_result = result.set_result
@@ -57,7 +57,7 @@ class _Shape(object):
             if done_callback is not None:
                 done_callback(indices)
 
-        id = nanome._internal._network.NetworkProcess._instance._send(nanome._internal._network._commands._callbacks._Messages.delete_shape, [self._index], True)
+        id = nanome._internal._network.PluginNetwork._instance._send(nanome._internal._network._commands._callbacks._Messages.delete_shape, [self._index], True)
         result = nanome.PluginInstance._save_callback(id, set_callback if done_callback else None)
         if done_callback is None and nanome.PluginInstance._instance.is_async:
             result.real_set_result = result.set_result
@@ -72,7 +72,7 @@ class _Shape(object):
                 done_callback(indices)
 
         indices = [x._index for x in shapes]
-        id = nanome._internal._network.NetworkProcess._instance._send(nanome._internal._network._commands._callbacks._Messages.delete_shape, indices, True)
+        id = nanome._internal._network.PluginNetwork._instance._send(nanome._internal._network._commands._callbacks._Messages.delete_shape, indices, True)
         result = nanome.PluginInstance._save_callback(id, set_callback if done_callback else None)
         if done_callback is None and nanome.PluginInstance._instance.is_async:
             result.real_set_result = result.set_result

--- a/nanome/_internal/_ui/_button.py
+++ b/nanome/_internal/_ui/_button.py
@@ -46,7 +46,7 @@ class _Button(_UIBase):
         if func == None and self._hover_callback == None:  # Low hanging filter but there may be others
             return
         try:
-            nanome._internal._network.NetworkProcess._instance._send(
+            nanome._internal._network.PluginNetwork._instance._send(
                 nanome._internal._network._commands._callbacks._Messages.hook_ui_callback,
                 (nanome._internal._network._commands._serialization._UIHook.Type.button_hover, self._content_id),
                 False)

--- a/nanome/_internal/_ui/_button.py
+++ b/nanome/_internal/_ui/_button.py
@@ -46,7 +46,7 @@ class _Button(_UIBase):
         if func == None and self._hover_callback == None:  # Low hanging filter but there may be others
             return
         try:
-            nanome._internal._network._ProcessNetwork._instance._send(
+            nanome._internal._network.NetworkProcess._instance._send(
                 nanome._internal._network._commands._callbacks._Messages.hook_ui_callback,
                 (nanome._internal._network._commands._serialization._UIHook.Type.button_hover, self._content_id),
                 False)

--- a/nanome/_internal/_ui/_image.py
+++ b/nanome/_internal/_ui/_image.py
@@ -51,7 +51,7 @@ class _Image(_UIBase):
 
     def _send_hook(self, hook_type):
         try:
-            nanome._internal._network.NetworkProcess._instance._send(
+            nanome._internal._network.PluginNetwork._instance._send(
                 nanome._internal._network._commands._callbacks._Messages.hook_ui_callback,
                 (hook_type, self._content_id),
                 False)

--- a/nanome/_internal/_ui/_image.py
+++ b/nanome/_internal/_ui/_image.py
@@ -51,7 +51,7 @@ class _Image(_UIBase):
 
     def _send_hook(self, hook_type):
         try:
-            nanome._internal._network._ProcessNetwork._instance._send(
+            nanome._internal._network.NetworkProcess._instance._send(
                 nanome._internal._network._commands._callbacks._Messages.hook_ui_callback,
                 (hook_type, self._content_id),
                 False)

--- a/nanome/api/plugin.py
+++ b/nanome/api/plugin.py
@@ -3,7 +3,7 @@ import sys
 from . import _DefaultPlugin
 from nanome._internal import _Plugin
 from nanome._internal.logs import LogsManager
-from nanome._internal._process import _ProcessManager
+from nanome._internal._process import ProcessManager
 from nanome.util.logs import Logs
 from nanome.util import config
 
@@ -121,7 +121,7 @@ class Plugin(_Plugin):
 
     @staticmethod
     def set_maximum_processes_count(max_process_nb):
-        _ProcessManager._max_process_count = max_process_nb
+        ProcessManager._max_process_count = max_process_nb
 
     @property
     def host(self):

--- a/nanome/api/structure/client/workspace_client.py
+++ b/nanome/api/structure/client/workspace_client.py
@@ -1,6 +1,6 @@
 import nanome
 from nanome._internal._addon import _Addon
-from nanome._internal._network import NetworkProcess
+from nanome._internal._network import PluginNetwork
 from nanome._internal._network._commands._callbacks import _Messages
 
 
@@ -11,5 +11,5 @@ class WorkspaceClient(_Addon):
     @classmethod
     def compute_hbonds(cls, callback=None):
         expects_response = callback is not None or nanome.PluginInstance._instance.is_async
-        id = NetworkProcess._send(_Messages.compute_hbonds, None, expects_response)
+        id = PluginNetwork._send(_Messages.compute_hbonds, None, expects_response)
         return nanome.PluginInstance._save_callback(id, callback)

--- a/nanome/api/structure/client/workspace_client.py
+++ b/nanome/api/structure/client/workspace_client.py
@@ -1,6 +1,6 @@
 import nanome
 from nanome._internal._addon import _Addon
-from nanome._internal._network import _ProcessNetwork
+from nanome._internal._network import NetworkProcess
 from nanome._internal._network._commands._callbacks import _Messages
 
 
@@ -11,5 +11,5 @@ class WorkspaceClient(_Addon):
     @classmethod
     def compute_hbonds(cls, callback=None):
         expects_response = callback is not None or nanome.PluginInstance._instance.is_async
-        id = _ProcessNetwork._send(_Messages.compute_hbonds, None, expects_response)
+        id = NetworkProcess._send(_Messages.compute_hbonds, None, expects_response)
         return nanome.PluginInstance._save_callback(id, callback)

--- a/nanome/api/structure/complex.py
+++ b/nanome/api/structure/complex.py
@@ -1,6 +1,6 @@
 from nanome._internal._structure._complex import _Complex
 from nanome._internal import _PluginInstance
-from nanome._internal._network import _ProcessNetwork
+from nanome._internal._network import NetworkProcess
 from nanome._internal._network._commands._callbacks import _Messages
 from nanome.util import Matrix, Logs
 from .io import ComplexIO
@@ -284,12 +284,12 @@ class Complex(_Complex, Base):
     def register_complex_updated_callback(self, callback):
         self._complex_updated_callback = callback
         _PluginInstance._hook_complex_updated(self.index, callback)
-        _ProcessNetwork._send(_Messages.hook_complex_updated, self.index, False)
+        NetworkProcess._send(_Messages.hook_complex_updated, self.index, False)
 
     def register_selection_changed_callback(self, callback):
         self._selection_changed_callback = callback
         _PluginInstance._hook_selection_changed(self.index, callback)
-        _ProcessNetwork._send(_Messages.hook_selection_changed, self.index, False)
+        NetworkProcess._send(_Messages.hook_selection_changed, self.index, False)
 
     @staticmethod
     def align_origins(target_complex, *other_complexes):

--- a/nanome/api/structure/complex.py
+++ b/nanome/api/structure/complex.py
@@ -1,6 +1,6 @@
 from nanome._internal._structure._complex import _Complex
 from nanome._internal import _PluginInstance
-from nanome._internal._network import NetworkProcess
+from nanome._internal._network import PluginNetwork
 from nanome._internal._network._commands._callbacks import _Messages
 from nanome.util import Matrix, Logs
 from .io import ComplexIO
@@ -284,12 +284,12 @@ class Complex(_Complex, Base):
     def register_complex_updated_callback(self, callback):
         self._complex_updated_callback = callback
         _PluginInstance._hook_complex_updated(self.index, callback)
-        NetworkProcess._send(_Messages.hook_complex_updated, self.index, False)
+        PluginNetwork._send(_Messages.hook_complex_updated, self.index, False)
 
     def register_selection_changed_callback(self, callback):
         self._selection_changed_callback = callback
         _PluginInstance._hook_selection_changed(self.index, callback)
-        NetworkProcess._send(_Messages.hook_selection_changed, self.index, False)
+        PluginNetwork._send(_Messages.hook_selection_changed, self.index, False)
 
     @staticmethod
     def align_origins(target_complex, *other_complexes):

--- a/nanome/api/structure/molecule.py
+++ b/nanome/api/structure/molecule.py
@@ -1,7 +1,6 @@
 import nanome
 from nanome._internal._structure._molecule import _Molecule
-from nanome._internal._network import _ProcessNetwork
-from nanome._internal import _PluginInstance
+from nanome._internal._network import NetworkProcess
 from nanome._internal._network._commands._callbacks import _Messages
 
 from nanome.util import Logs
@@ -172,22 +171,22 @@ class Molecule(_Molecule, Base):
 
     def get_substructures(self, callback=None):
         expects_response = callback is not None or nanome.PluginInstance._instance.is_async
-        id = _ProcessNetwork._send(_Messages.substructure_request, (self.index, nanome.util.enums.SubstructureType.Unkown), expects_response)
+        id = NetworkProcess._send(_Messages.substructure_request, (self.index, nanome.util.enums.SubstructureType.Unkown), expects_response)
         return nanome.PluginInstance._save_callback(id, callback)
 
     def get_ligands(self, callback=None):
         expects_response = callback is not None or nanome.PluginInstance._instance.is_async
-        id = _ProcessNetwork._send(_Messages.substructure_request, (self.index, nanome.util.enums.SubstructureType.Ligand), expects_response)
+        id = NetworkProcess._send(_Messages.substructure_request, (self.index, nanome.util.enums.SubstructureType.Ligand), expects_response)
         return nanome.PluginInstance._save_callback(id, callback)
 
     def get_proteins(self, callback=None):
         expects_response = callback is not None or nanome.PluginInstance._instance.is_async
-        id = _ProcessNetwork._send(_Messages.substructure_request, (self.index, nanome.util.enums.SubstructureType.Protein), expects_response)
+        id = NetworkProcess._send(_Messages.substructure_request, (self.index, nanome.util.enums.SubstructureType.Protein), expects_response)
         return nanome.PluginInstance._save_callback(id, callback)
 
     def get_solvents(self, callback=None):
         expects_response = callback is not None or nanome.PluginInstance._instance.is_async
-        id = _ProcessNetwork._send(_Messages.substructure_request, (self.index, nanome.util.enums.SubstructureType.Solvent), expects_response)
+        id = NetworkProcess._send(_Messages.substructure_request, (self.index, nanome.util.enums.SubstructureType.Solvent), expects_response)
         return nanome.PluginInstance._save_callback(id, callback)
 
     # region deprecated

--- a/nanome/api/structure/molecule.py
+++ b/nanome/api/structure/molecule.py
@@ -1,6 +1,6 @@
 import nanome
 from nanome._internal._structure._molecule import _Molecule
-from nanome._internal._network import NetworkProcess
+from nanome._internal._network import PluginNetwork
 from nanome._internal._network._commands._callbacks import _Messages
 
 from nanome.util import Logs
@@ -171,22 +171,22 @@ class Molecule(_Molecule, Base):
 
     def get_substructures(self, callback=None):
         expects_response = callback is not None or nanome.PluginInstance._instance.is_async
-        id = NetworkProcess._send(_Messages.substructure_request, (self.index, nanome.util.enums.SubstructureType.Unkown), expects_response)
+        id = PluginNetwork._send(_Messages.substructure_request, (self.index, nanome.util.enums.SubstructureType.Unkown), expects_response)
         return nanome.PluginInstance._save_callback(id, callback)
 
     def get_ligands(self, callback=None):
         expects_response = callback is not None or nanome.PluginInstance._instance.is_async
-        id = NetworkProcess._send(_Messages.substructure_request, (self.index, nanome.util.enums.SubstructureType.Ligand), expects_response)
+        id = PluginNetwork._send(_Messages.substructure_request, (self.index, nanome.util.enums.SubstructureType.Ligand), expects_response)
         return nanome.PluginInstance._save_callback(id, callback)
 
     def get_proteins(self, callback=None):
         expects_response = callback is not None or nanome.PluginInstance._instance.is_async
-        id = NetworkProcess._send(_Messages.substructure_request, (self.index, nanome.util.enums.SubstructureType.Protein), expects_response)
+        id = PluginNetwork._send(_Messages.substructure_request, (self.index, nanome.util.enums.SubstructureType.Protein), expects_response)
         return nanome.PluginInstance._save_callback(id, callback)
 
     def get_solvents(self, callback=None):
         expects_response = callback is not None or nanome.PluginInstance._instance.is_async
-        id = NetworkProcess._send(_Messages.substructure_request, (self.index, nanome.util.enums.SubstructureType.Solvent), expects_response)
+        id = PluginNetwork._send(_Messages.substructure_request, (self.index, nanome.util.enums.SubstructureType.Solvent), expects_response)
         return nanome.PluginInstance._save_callback(id, callback)
 
     # region deprecated

--- a/nanome/util/process.py
+++ b/nanome/util/process.py
@@ -126,11 +126,11 @@ class Process():
         self.__request.label = value
 
     @property
-    def _id(self):
+    def id(self):
         return self.__request.id
 
-    @_id.setter
-    def _id(self, value):
+    @id.setter
+    def id(self, value):
         self.__request.id = value
 
     @property
@@ -165,11 +165,11 @@ class Process():
             self.on_error(result.stderr)
             self._future.set_result(result.returncode)
         else:
-            Process._manager.start_process(self, self.__request)
+            Process.manager.start_process(self, self.__request)
         return self._future
 
     def stop(self):
         """
         | Stops the process.
         """
-        Process._manager.stop_process(self)
+        Process.manager.stop_process(self)

--- a/nanome/util/process.py
+++ b/nanome/util/process.py
@@ -149,7 +149,7 @@ class Process():
             future = loop.create_future()
             self._future = future
 
-        if self.manager is None:
+        if self._manager is None:
             nanome.util.Logs.warning("Running process outside of ProcessManager. This should only happen during unittests.")
             cmd = [self.executable_path] + self.args
             result = subprocess.run(cmd, capture_output=True, text=self.output_text)
@@ -157,14 +157,14 @@ class Process():
             self.on_error(result.stderr)
             self._future.set_result(result.returncode)
         else:
-            Process.manager.start_process(self, self.__request)
+            Process._manager.start_process(self, self.__request)
         return self._future
 
     def stop(self):
         """
         | Stops the process.
         """
-        Process.manager.stop_process(self)
+        Process._manager.stop_process(self)
 
     @property
     def id(self):

--- a/nanome/util/process.py
+++ b/nanome/util/process.py
@@ -126,14 +126,6 @@ class Process():
         self.__request.label = value
 
     @property
-    def id(self):
-        return self.__request.id
-
-    @id.setter
-    def id(self, value):
-        self.__request.id = value
-
-    @property
     def timeout(self):
         """
         | The timeout in seconds for this process to be killed.
@@ -173,3 +165,11 @@ class Process():
         | Stops the process.
         """
         Process.manager.stop_process(self)
+    
+    @property
+    def id(self):
+        return self.__request.id
+
+    @id.setter
+    def id(self, value):
+        self.__request.id = value

--- a/nanome/util/process.py
+++ b/nanome/util/process.py
@@ -149,7 +149,7 @@ class Process():
             future = loop.create_future()
             self._future = future
 
-        if self._manager is None:
+        if self.manager is None:
             nanome.util.Logs.warning("Running process outside of ProcessManager. This should only happen during unittests.")
             cmd = [self.executable_path] + self.args
             result = subprocess.run(cmd, capture_output=True, text=self.output_text)

--- a/nanome/util/process.py
+++ b/nanome/util/process.py
@@ -165,7 +165,7 @@ class Process():
         | Stops the process.
         """
         Process.manager.stop_process(self)
-    
+
     @property
     def id(self):
         return self.__request.id

--- a/testing/plugin_tests.py
+++ b/testing/plugin_tests.py
@@ -4,7 +4,7 @@ import sys
 import unittest
 
 from nanome import Plugin, PluginInstance
-from nanome._internal._process import _ProcessManager
+from nanome._internal._process import ProcessManager
 from nanome.util import config
 
 if sys.version_info.major >= 3:
@@ -101,7 +101,7 @@ class PluginTestCase(unittest.TestCase):
     def test_set_maximum_processes_count(self):
         new_value = 5
         self.plugin.set_maximum_processes_count(new_value)
-        self.assertEqual(_ProcessManager._max_process_count, new_value)
+        self.assertEqual(ProcessManager._max_process_count, new_value)
 
     def test_pre_and_post_run(self):
         def test_callback_fn():


### PR DESCRIPTION
- Remove underscores from classes and attributes that are utilized outside of class itself
- Rename _ProcessNetwork to NetworkProcess. Emphasizes that it is part of networking code, not Process API
- Move __inits__ to top of classes