### PR TITLE
Make Color.hex output like #ffffffff

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install Python 3
         uses: actions/setup-python@v1
         with:
-          python-version: 3.7.12
+          python-version: 3.7.13
       - name: Install Dependencies
         run: |
           python -m pip install bump2version setuptools wheel twine

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install Python 3
         uses: actions/setup-python@v1
         with:
-          python-version: 3.7.12
+          python-version: 3.7.13
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip coverage
@@ -27,7 +27,7 @@ jobs:
 
   python2:
     runs-on: ubuntu-latest
-    if: ${{ false }}  # disable for now
+    if: ${{ false }} # disable for now
     steps:
       - uses: actions/checkout@v2
       - name: Install Python 2

--- a/nanome/util/color.py
+++ b/nanome/util/color.py
@@ -195,7 +195,7 @@ class Color(object):
 
         :rtype: class:`str`
         """
-        return hex(self._color)
+        return '#' + hex(self._color)[2:].rjust(8, '0')
 
     @property
     def rgb(self):

--- a/nanome/util/color.py
+++ b/nanome/util/color.py
@@ -56,6 +56,18 @@ class Color(object):
         self._color = r << 24 | g << 16 | b << 8 | a
 
     @classmethod
+    def from_hex(cls, value):
+        """
+        | Set color from hex after initializing.
+
+        :param value: Hex value of the color e.g. #ffffffff
+        :type value: :class:`str`
+        """
+        color = Color()
+        color.hex = value
+        return color
+
+    @classmethod
     def from_int(cls, value):
         """
         | Set color from int after initializing.
@@ -189,13 +201,30 @@ class Color(object):
         """
         return Color(whole_num=self._color)
 
-    def to_string_hex(self):
+    @property
+    def hex(self):
         """
-        | Returns a hex string representing the color.
+        | Hex string representing the RGBA color.
+        | e.g. #ffffffff
 
         :rtype: class:`str`
         """
         return '#' + hex(self._color)[2:].rjust(8, '0')
+
+    @hex.setter
+    def hex(self, value):
+        v = value.lower()
+        if v.startswith('#'):
+            v = v[1:]
+        if len(v) not in [3, 4, 6, 8]:
+            raise ValueError('Invalid hex value: ' + value)
+        if len(v) == 3:  # rgb -> rrggbb
+            v = v[0] + v[0] + v[1] + v[1] + v[2] + v[2]
+        if len(v) == 4:  # rgba -> rrggbbaa
+            v = v[0] + v[0] + v[1] + v[1] + v[2] + v[2] + v[3] + v[3]
+        if len(v) == 6:  # rrggbb -> rrggbbaa
+            v += 'ff'
+        self._color = int(v, 16)
 
     @property
     def rgb(self):

--- a/testing/color_tests.py
+++ b/testing/color_tests.py
@@ -15,3 +15,37 @@ class TestColorProperties(unittest.TestCase):
         rgba = color.rgba
         assert isinstance(rgba, tuple)
         assert len(rgba) == 4
+
+    def test_hex(self):
+        color = Color.Red()
+        hex = color.hex
+        assert isinstance(hex, str)
+        assert hex == '#ff0000ff'
+
+    def test_from_hex_rgb(self):
+        color = Color.from_hex('#f00')
+        assert isinstance(color, Color)
+        assert color.rgba == (255, 0, 0, 255)
+
+    def test_from_hex_rgba(self):
+        color = Color.from_hex('#f001')
+        assert isinstance(color, Color)
+        assert color.rgba == (255, 0, 0, 17)
+
+    def test_from_hex_rrggbb(self):
+        color = Color.from_hex('#ff0000')
+        assert isinstance(color, Color)
+        assert color.rgba == (255, 0, 0, 255)
+
+    def test_from_hex_rrggbbaa(self):
+        color = Color.from_hex('#ff0000ff')
+        assert isinstance(color, Color)
+        assert color.rgba == (255, 0, 0, 255)
+
+    def test_from_hex_invalid_hex(self):
+        with self.assertRaises(ValueError):
+            Color.from_hex('#f00g')
+
+    def test_from_hex_invalid_len(self):
+        with self.assertRaises(ValueError):
+            Color.from_hex('#ff')


### PR DESCRIPTION
`Color.to_string_hex` was not exactly useful. There were no leading zeroes, and it was prefixed with `0x`.

A color like cyan would output as `0xffff` (0 R, 0 G, 255 B, 255 A).
This PR outputs in hex RGBA with a `#` prefix, so cyan = `#0000ffff`.