### PR TITLE
Split out util.Log tests into their own testcase

### DIFF
--- a/testing/logging_tests.py
+++ b/testing/logging_tests.py
@@ -128,7 +128,6 @@ class LoggingTestCase(unittest.TestCase):
 
         Logs.warning("This is a warning")
         Logs.error("This is an error")
-        breakpoint()
         Logs.debug("This is a debug message")
         Logs.message("This is a regular message")
 

--- a/testing/logging_tests.py
+++ b/testing/logging_tests.py
@@ -41,7 +41,7 @@ class PluginLoggingTestCase(unittest.TestCase):
     @patch('nanome._internal._plugin._Plugin._run')
     @patch('nanome._internal._plugin.Network._NetInstance')
     @patch('nanome._internal.logs.NTSLoggingHandler.handle')
-    def test_nts_handler_called(self, handle_mock, netinstance_mock, loop_mock):
+    def test_nts_handler_called(self, handle_mock, *args):
         """Assert logs get forwarded to NTS."""
         remote_logging = "True"
         testargs = [
@@ -59,7 +59,7 @@ class PluginLoggingTestCase(unittest.TestCase):
     @patch('nanome._internal._plugin._Plugin._loop')
     @patch('nanome._internal._plugin.Network._NetInstance')
     @patch('nanome._internal.logs.NTSLoggingHandler.handle')
-    def test_nts_handler_not_called(self, handle_mock, netinstance_mock, loop_mock):
+    def test_nts_handler_not_called(self, *args):
         """Assert logs don't get forwarded to NTS if remote-logging is False."""
         remote_logging = False
 
@@ -79,7 +79,7 @@ class PluginLoggingTestCase(unittest.TestCase):
 
     @patch('nanome._internal._plugin._Plugin._loop')
     @patch('nanome._internal._plugin.Network._NetInstance')
-    def test_file_handler_called(self, netinstance_mock, loop_mock):
+    def test_file_handler_called(self, *args):
         """Assert if write_log_file is True, the log_file_handler is utilized."""
         write_log_file = "True"
         testargs = [
@@ -96,7 +96,7 @@ class PluginLoggingTestCase(unittest.TestCase):
 
     @patch('nanome._internal._plugin._Plugin._loop')
     @patch('nanome._internal._plugin.Network._NetInstance')
-    def test_file_handler_not_called(self, netinstance_mock, loop_mock):
+    def test_file_handler_not_called(self, *args):
         """Assert if write_log_file is False, the log_file_handler is not utilized."""
         write_log_file = False
         testargs = [
@@ -112,7 +112,7 @@ class PluginLoggingTestCase(unittest.TestCase):
     @patch('nanome._internal._plugin._Plugin._loop')
     @patch('nanome._internal._plugin.Network._NetInstance.connect')
     @patch('nanome._internal._plugin.Network._NetInstance.send')
-    def test_nts_logger_handler(self, send_mock, connect_mock, loop_mock):
+    def test_nts_logger_handler(self, send_mock, *args):
         """Ensure NTSLoggingHandler.handle() triggers a network request."""
         with patch.object(sys, 'argv', ['run.py', '--remote-logging', 'True']):
             self.plugin.run(self.host, self.port, self.key)
@@ -120,7 +120,7 @@ class PluginLoggingTestCase(unittest.TestCase):
 
     @patch('nanome._internal._plugin._Plugin._loop')
     @patch('nanome._internal._plugin.Network._NetInstance')
-    def test_console_handler_called(self, netinstance_mock, loop_mock):
+    def test_console_handler_called(self, *args):
         """Assert logs are always logged to the console."""
         testargs = [
             'run.py',
@@ -146,26 +146,26 @@ class LogUtilTestCase(unittest.TestCase):
         with self.assertLogs(self.logger, logging.WARNING) as captured:
             message = "This is a warning"
             Logs.warning(message)
-            self.assertEqual(len(captured.records), 1) # check that there is only one log message
-            self.assertEqual(captured.records[0].getMessage(), message) # and it is the proper one
+            self.assertEqual(len(captured.records), 1)
+            self.assertEqual(captured.records[0].getMessage(), message)
 
     def test_log_error(self):
         with self.assertLogs(self.logger, logging.ERROR) as captured:
             message = "This is an error"
             Logs.error(message)
-            self.assertEqual(len(captured.records), 1) # check that there is only one log message
-            self.assertEqual(captured.records[0].getMessage(), message) # and it is the proper one
+            self.assertEqual(len(captured.records), 1)
+            self.assertEqual(captured.records[0].getMessage(), message)
 
     def test_log_debug(self):
         with self.assertLogs(self.logger, logging.DEBUG) as captured:
             message = "This is a debug message"
             Logs.debug(message)
-            self.assertEqual(len(captured.records), 1) # check that there is only one log message
-            self.assertEqual(captured.records[0].getMessage(), message) # and it is the proper one
+            self.assertEqual(len(captured.records), 1)
+            self.assertEqual(captured.records[0].getMessage(), message)
 
     def test_log_message(self):
         with self.assertLogs(self.logger, logging.INFO) as captured:
             message = "This is a regular messge"
             Logs.message(message)
-            self.assertEqual(len(captured.records), 1) # check that there is only one log message
-            self.assertEqual(captured.records[0].getMessage(), message) # and it is the proper one
+            self.assertEqual(len(captured.records), 1)
+            self.assertEqual(captured.records[0].getMessage(), message)

--- a/testing/logging_tests.py
+++ b/testing/logging_tests.py
@@ -141,7 +141,7 @@ class PluginLoggingTestCase(unittest.TestCase):
 
 
 class LogUtilTestCase(unittest.TestCase):
-    
+
     def setUp(self):
         self.logger = logging.getLogger(__name__)
         self.logger.setLevel(logging.INFO)

--- a/testing/logging_tests.py
+++ b/testing/logging_tests.py
@@ -23,7 +23,7 @@ class LoggingTestCase(unittest.TestCase):
         self.key = ''
 
         # Make it so that Logs logged in this module are handled the same as "nanome"
-        testing_logger = logging.getLogger('logging_tests')
+        testing_logger = logging.getLogger(__name__)
         nanome_logger = logging.getLogger('nanome')
         testing_logger.handlers = nanome_logger.handlers
         testing_logger.setLevel(logging.DEBUG)
@@ -42,6 +42,7 @@ class LoggingTestCase(unittest.TestCase):
     @patch('nanome._internal._plugin._Plugin._loop')
     @patch('nanome._internal._plugin.Network._NetInstance')
     @patch('nanome._internal.logs.NTSLoggingHandler.handle')
+    @unittest.skip('')
     def test_nts_handler_called(self, handle_mock, netinstance_mock, loop_mock):
         """Assert logs get forwarded to NTS."""
         remote_logging = "True"
@@ -60,6 +61,7 @@ class LoggingTestCase(unittest.TestCase):
     @patch('nanome._internal._plugin._Plugin._loop')
     @patch('nanome._internal._plugin.Network._NetInstance')
     @patch('nanome._internal.logs.NTSLoggingHandler.handle')
+    @unittest.skip('')
     def test_nts_handler_not_called(self, handle_mock, netinstance_mock, loop_mock):
         """Assert logs don't get forwarded to NTS if remote-logging is False."""
         remote_logging = False
@@ -80,6 +82,7 @@ class LoggingTestCase(unittest.TestCase):
 
     @patch('nanome._internal._plugin._Plugin._loop')
     @patch('nanome._internal._plugin.Network._NetInstance')
+    @unittest.skip('')
     def test_file_handler_called(self, netinstance_mock, loop_mock):
         """Assert if write_log_file is True, the log_file_handler is utilized."""
         write_log_file = "True"
@@ -97,6 +100,7 @@ class LoggingTestCase(unittest.TestCase):
 
     @patch('nanome._internal._plugin._Plugin._loop')
     @patch('nanome._internal._plugin.Network._NetInstance')
+    @unittest.skip('')
     def test_file_handler_not_called(self, netinstance_mock, loop_mock):
         """Assert if write_log_file is False, the log_file_handler is not utilized."""
         write_log_file = False
@@ -113,6 +117,7 @@ class LoggingTestCase(unittest.TestCase):
     @patch('nanome._internal._plugin._Plugin._loop')
     @patch('nanome._internal._plugin.Network._NetInstance.connect')
     @patch('nanome._internal._plugin.Network._NetInstance.send')
+    @unittest.skip('')
     def test_nts_logger_handler(self, send_mock, connect_mock, loop_mock):
         """Ensure NTSLoggingHandler.handle() triggers a network request."""
         with patch.object(sys, 'argv', ['run.py', '--remote-logging', 'True']):
@@ -128,11 +133,13 @@ class LoggingTestCase(unittest.TestCase):
 
         Logs.warning("This is a warning")
         Logs.error("This is an error")
+        breakpoint()
         Logs.debug("This is a debug message")
         Logs.message("This is a regular message")
 
     @patch('nanome._internal._plugin._Plugin._loop')
     @patch('nanome._internal._plugin.Network._NetInstance')
+    @unittest.skip('')
     def test_console_handler_called(self, netinstance_mock, loop_mock):
         """Assert logs are always logged to the console."""
         testargs = [

--- a/testing/logging_tests.py
+++ b/testing/logging_tests.py
@@ -42,7 +42,6 @@ class LoggingTestCase(unittest.TestCase):
     @patch('nanome._internal._plugin._Plugin._loop')
     @patch('nanome._internal._plugin.Network._NetInstance')
     @patch('nanome._internal.logs.NTSLoggingHandler.handle')
-    @unittest.skip('')
     def test_nts_handler_called(self, handle_mock, netinstance_mock, loop_mock):
         """Assert logs get forwarded to NTS."""
         remote_logging = "True"
@@ -61,7 +60,6 @@ class LoggingTestCase(unittest.TestCase):
     @patch('nanome._internal._plugin._Plugin._loop')
     @patch('nanome._internal._plugin.Network._NetInstance')
     @patch('nanome._internal.logs.NTSLoggingHandler.handle')
-    @unittest.skip('')
     def test_nts_handler_not_called(self, handle_mock, netinstance_mock, loop_mock):
         """Assert logs don't get forwarded to NTS if remote-logging is False."""
         remote_logging = False
@@ -82,7 +80,6 @@ class LoggingTestCase(unittest.TestCase):
 
     @patch('nanome._internal._plugin._Plugin._loop')
     @patch('nanome._internal._plugin.Network._NetInstance')
-    @unittest.skip('')
     def test_file_handler_called(self, netinstance_mock, loop_mock):
         """Assert if write_log_file is True, the log_file_handler is utilized."""
         write_log_file = "True"
@@ -100,7 +97,6 @@ class LoggingTestCase(unittest.TestCase):
 
     @patch('nanome._internal._plugin._Plugin._loop')
     @patch('nanome._internal._plugin.Network._NetInstance')
-    @unittest.skip('')
     def test_file_handler_not_called(self, netinstance_mock, loop_mock):
         """Assert if write_log_file is False, the log_file_handler is not utilized."""
         write_log_file = False
@@ -117,7 +113,6 @@ class LoggingTestCase(unittest.TestCase):
     @patch('nanome._internal._plugin._Plugin._loop')
     @patch('nanome._internal._plugin.Network._NetInstance.connect')
     @patch('nanome._internal._plugin.Network._NetInstance.send')
-    @unittest.skip('')
     def test_nts_logger_handler(self, send_mock, connect_mock, loop_mock):
         """Ensure NTSLoggingHandler.handle() triggers a network request."""
         with patch.object(sys, 'argv', ['run.py', '--remote-logging', 'True']):
@@ -139,7 +134,6 @@ class LoggingTestCase(unittest.TestCase):
 
     @patch('nanome._internal._plugin._Plugin._loop')
     @patch('nanome._internal._plugin.Network._NetInstance')
-    @unittest.skip('')
     def test_console_handler_called(self, netinstance_mock, loop_mock):
         """Assert logs are always logged to the console."""
         testargs = [

--- a/testing/logging_tests.py
+++ b/testing/logging_tests.py
@@ -26,7 +26,11 @@ class PluginLoggingTestCase(unittest.TestCase):
         testing_logger = logging.getLogger(__name__)
         nanome_logger = logging.getLogger('nanome')
         testing_logger.handlers = nanome_logger.handlers
-        testing_logger.setLevel(logging.DEBUG)
+        testing_logger.setLevel(logging.INFO)
+        nanome_logger.setLevel(logging.WARNING)
+
+        # Hides noisy "Starting Plugin" output
+        logging.getLogger('nanome.api.plugin.Plugin.run').setLevel(logging.ERROR)
 
     @classmethod
     def tearDownClass(cls):
@@ -56,7 +60,7 @@ class PluginLoggingTestCase(unittest.TestCase):
         Logs.message('This should be forwarded to NTS.')
         handle_mock.assert_called()
 
-    @patch('nanome._internal._plugin._Plugin._loop')
+    @patch('nanome._internal._plugin._Plugin._run')
     @patch('nanome._internal._plugin.Network._NetInstance')
     @patch('nanome._internal.logs.NTSLoggingHandler.handle')
     def test_nts_handler_not_called(self, *args):
@@ -77,7 +81,7 @@ class PluginLoggingTestCase(unittest.TestCase):
         nts_handler = self.plugin._logs_manager.nts_handler
         self.assertTrue(isinstance(nts_handler, logging.NullHandler))
 
-    @patch('nanome._internal._plugin._Plugin._loop')
+    @patch('nanome._internal._plugin._Plugin._run')
     @patch('nanome._internal._plugin.Network._NetInstance')
     def test_file_handler_called(self, *args):
         """Assert if write_log_file is True, the log_file_handler is utilized."""
@@ -94,7 +98,7 @@ class PluginLoggingTestCase(unittest.TestCase):
         Logs.message('Log file handler should be called.')
         self.plugin._logs_manager.log_file_handler.handle.assert_called()
 
-    @patch('nanome._internal._plugin._Plugin._loop')
+    @patch('nanome._internal._plugin._Plugin._run')
     @patch('nanome._internal._plugin.Network._NetInstance')
     def test_file_handler_not_called(self, *args):
         """Assert if write_log_file is False, the log_file_handler is not utilized."""
@@ -118,7 +122,7 @@ class PluginLoggingTestCase(unittest.TestCase):
             self.plugin.run(self.host, self.port, self.key)
         send_mock.assert_called()
 
-    @patch('nanome._internal._plugin._Plugin._loop')
+    @patch('nanome._internal._plugin._Plugin._run')
     @patch('nanome._internal._plugin.Network._NetInstance')
     def test_console_handler_called(self, *args):
         """Assert logs are always logged to the console."""
@@ -140,7 +144,7 @@ class LogUtilTestCase(unittest.TestCase):
     
     def setUp(self):
         self.logger = logging.getLogger(__name__)
-        self.logger.level = logging.DEBUG
+        self.logger.setLevel(logging.INFO)
 
     def test_log_warning(self):
         with self.assertLogs(self.logger, logging.WARNING) as captured:

--- a/testing/logging_tests.py
+++ b/testing/logging_tests.py
@@ -23,7 +23,7 @@ class LoggingTestCase(unittest.TestCase):
         self.key = ''
 
         # Make it so that Logs logged in this module are handled the same as "nanome"
-        testing_logger = logging.getLogger('logging_tests')
+        testing_logger = logging.getLogger(__name__)
         nanome_logger = logging.getLogger('nanome')
         testing_logger.handlers = nanome_logger.handlers
         testing_logger.setLevel(logging.DEBUG)
@@ -34,7 +34,7 @@ class LoggingTestCase(unittest.TestCase):
         # Without this teardown, logging configs persist to tests run after this.
         super(LoggingTestCase, cls).tearDownClass()
         nanome_logger = logging.getLogger("nanome")
-        testing_logger = logging.getLogger(__name__)
+        testing_logger = logging.getLogger('logging_tests')
 
         nanome_logger.handlers = []
         testing_logger.handlers = []
@@ -122,58 +122,27 @@ class LoggingTestCase(unittest.TestCase):
     @patch('nanome._internal._plugin._Plugin._loop')
     @patch('nanome._internal._plugin.Network._NetInstance.connect')
     @patch('nanome._internal._plugin.Network._NetInstance.send')
-    def test_log_warning(self, *args):
-        with patch.object(sys, 'argv', ['run.py']):
+    def test_log_types(self, send_mock, connect_mock, loop_mock):
+        with patch.object(sys, 'argv', ['run.py', '-v', '--remote-logging', 'True', '--write-log-file', 'True']):
             self.plugin.run(self.host, self.port, self.key)
-
+    
         with self.assertLogs() as captured:
             message = "This is a warning"
             Logs.warning(message)
             self.assertEqual(len(captured.records), 1) # check that there is only one log message
             self.assertEqual(captured.records[0].getMessage(), message) # and it is the proper one
 
-    @patch('nanome._internal._plugin._Plugin._loop')
-    @patch('nanome._internal._plugin.Network._NetInstance.connect')
-    @patch('nanome._internal._plugin.Network._NetInstance.send')
-    def test_log_error(self, *args):
-        with patch.object(sys, 'argv', ['run.py']):
-            self.plugin.run(self.host, self.port, self.key)
-
         with self.assertLogs() as captured:
             message = "This is an error"
             Logs.error(message)
             self.assertEqual(len(captured.records), 1) # check that there is only one log message
-
             self.assertEqual(captured.records[0].getMessage(), message) # and it is the proper one
 
-    @patch('nanome._internal._plugin._Plugin._loop')
-    @patch('nanome._internal._plugin.Network._NetInstance.connect')
-    @patch('nanome._internal._plugin.Network._NetInstance.send')
-    def test_log_debug(self, *args):
-        # -v flag not set, so debug messages should not be logged
-        with patch.object(sys, 'argv', ['run.py']):
-            self.plugin.run(self.host, self.port, self.key)
-        with self.assertLogs() as captured:
-            message = "This debug message should not be logged"
-            Logs.debug(message)
-            self.assertEqual(len(captured.records), 0) # check that there is only one log message
-        
-        # This time we should get the debug log
-        with patch.object(sys, 'argv', ['run.py', '-v']):
-            self.plugin.run(self.host, self.port, self.key)
-        
         with self.assertLogs() as captured:
             message = "This is a debug message"
             Logs.debug(message)
             self.assertEqual(len(captured.records), 1) # check that there is only one log message
             self.assertEqual(captured.records[0].getMessage(), message) # and it is the proper one
-
-    @patch('nanome._internal._plugin._Plugin._loop')
-    @patch('nanome._internal._plugin.Network._NetInstance.connect')
-    @patch('nanome._internal._plugin.Network._NetInstance.send')
-    def test_log_message(self, *args):
-        with patch.object(sys, 'argv', ['run.py']):
-            self.plugin.run(self.host, self.port, self.key)
 
         with self.assertLogs() as captured:
             message = "This is a regular messge"


### PR DESCRIPTION
* Tests for util.Logs that actually validate output
*  use __name__ instead of hardcoding "logging_tests", which makes tests more robust