### PR TITLE
Structure schema fix

### DIFF
--- a/nanome/api/schemas/structure_schemas.py
+++ b/nanome/api/schemas/structure_schemas.py
@@ -195,30 +195,18 @@ class StructureSchema(Schema):
 
     def determine_structure_schema(self, data):
         """Use unique fields to determine schema to use for provided data."""
-        complex_fields = list(ComplexSchema._declared_fields.keys())
-        molecule_fields = list(MoleculeSchema._declared_fields.keys())
-        chain_fields = list(ChainSchema._declared_fields.keys())
-        residue_fields = list(ResidueSchema._declared_fields.keys())
-        atom_fields = list(AtomSchema._declared_fields.keys())
-        bond_fields = list(BondSchema._declared_fields.keys())
-        unique_complex_fields = [
-            field for field in complex_fields
-            if field not in set(molecule_fields + chain_fields + residue_fields + atom_fields + bond_fields)]
-        unique_molecule_fields = [
-            field for field in molecule_fields
-            if field not in set(complex_fields + chain_fields + residue_fields + atom_fields + bond_fields)]
-        unique_chain_fields = [
-            field for field in chain_fields
-            if field not in set(complex_fields + molecule_fields + residue_fields + atom_fields + bond_fields)]
-        unique_residue_fields = [
-            field for field in residue_fields
-            if field not in set(complex_fields + molecule_fields + chain_fields + atom_fields + bond_fields)]
-        unique_bond_fields = [
-            field for field in bond_fields
-            if field not in set(complex_fields + molecule_fields + chain_fields + residue_fields + atom_fields)]
-        unique_atom_fields = [
-            field for field in atom_fields
-            if field not in set(complex_fields + molecule_fields + chain_fields + residue_fields + bond_fields)]
+        complex_fields = set(ComplexSchema._declared_fields.keys())
+        molecule_fields = set(MoleculeSchema._declared_fields.keys())
+        chain_fields = set(ChainSchema._declared_fields.keys())
+        residue_fields = set(ResidueSchema._declared_fields.keys())
+        atom_fields = set(AtomSchema._declared_fields.keys())
+        bond_fields = set(BondSchema._declared_fields.keys())
+        unique_complex_fields = complex_fields - molecule_fields - chain_fields - residue_fields - atom_fields - bond_fields
+        unique_molecule_fields = molecule_fields - complex_fields - chain_fields - residue_fields - atom_fields - bond_fields
+        unique_chain_fields = chain_fields - complex_fields - molecule_fields - residue_fields - atom_fields - bond_fields
+        unique_residue_fields = residue_fields - complex_fields - molecule_fields - chain_fields - atom_fields - bond_fields
+        unique_bond_fields = bond_fields - complex_fields - molecule_fields - chain_fields - residue_fields - atom_fields
+        unique_atom_fields = atom_fields - complex_fields - molecule_fields - chain_fields - residue_fields - bond_fields
 
         schema = None
         if any(data.get(key) for key in unique_complex_fields):

--- a/nanome/api/schemas/structure_schemas.py
+++ b/nanome/api/schemas/structure_schemas.py
@@ -183,7 +183,18 @@ class StructureSchema(Schema):
         structure.Complex: ComplexSchema(),
     }
 
+    def dump(self, obj, *args, **kwargs):
+        obj_class = obj.__class__
+        schema = self.structure_schema_map[obj_class]
+        dump_data = schema.dump(obj, *args, **kwargs)
+        return dump_data
+
+    def load(self, data, *args, **kwargs):
+        correct_schema = self.determine_structure_schema(data)
+        return correct_schema.load(data, *args, **kwargs)
+
     def determine_structure_schema(self, data):
+        """Use unique fields to determine schema to use for provided data."""
         complex_fields = list(ComplexSchema._declared_fields.keys())
         molecule_fields = list(MoleculeSchema._declared_fields.keys())
         chain_fields = list(ChainSchema._declared_fields.keys())
@@ -228,13 +239,3 @@ class StructureSchema(Schema):
         if not schema:
             raise ValueError('Could not determine structure schema')
         return schema
-
-    def dump(self, obj, *args, **kwargs):
-        obj_class = obj.__class__
-        schema = self.structure_schema_map[obj_class]
-        dump_data = schema.dump(obj, *args, **kwargs)
-        return dump_data
-
-    def load(self, data, *args, **kwargs):
-        correct_schema = self.determine_structure_schema(data)
-        return correct_schema.load(data, *args, **kwargs)

--- a/nanome/api/schemas/structure_schemas.py
+++ b/nanome/api/schemas/structure_schemas.py
@@ -16,11 +16,8 @@ def init_object(obj, data: dict):
             raise AttributeError('Could not set attribute {}'.format(key))
 
 
-class StructureSchema(Schema):
+class AtomSchema(Schema):
     index = fields.Integer(default=-1)
-
-
-class AtomSchema(StructureSchema):
     selected = fields.Boolean()
     labeled = fields.Boolean()
     atom_rendering = fields.Boolean()
@@ -61,12 +58,13 @@ class AtomSchema(StructureSchema):
         return new_obj
 
 
-class BondSchema(StructureSchema):
-    atom1 = AtomSchema(only=('index',))
-    atom2 = AtomSchema(only=('index',))
+class BondSchema(Schema):
+    index = fields.Integer(default=-1)
+    atom1 = fields.Nested(AtomSchema(only=('index',)))
+    atom2 = fields.Nested(AtomSchema(only=('index',)))
     kind = EnumField(enum=enums.Kind)
     in_conformer = fields.List(fields.Boolean())
-    kinds = fields.List(fields.Nested(EnumField(enum=enums.Kind)))
+    kinds = fields.List(EnumField(enum=enums.Kind))
 
     @post_load
     def make_bond(self, data, **kwargs):
@@ -75,7 +73,8 @@ class BondSchema(StructureSchema):
         return new_obj
 
 
-class ResidueSchema(StructureSchema):
+class ResidueSchema(Schema):
+    index = fields.Integer(default=-1)
     atoms = fields.List(fields.Nested(AtomSchema))
     bonds = fields.List(fields.Nested(BondSchema))
     ribboned = fields.Boolean()
@@ -99,7 +98,8 @@ class ResidueSchema(StructureSchema):
         return new_obj
 
 
-class ChainSchema(StructureSchema):
+class ChainSchema(Schema):
+    index = fields.Integer(default=-1)
     name = fields.Str()
     residues = fields.Nested(ResidueSchema, many=True)
 
@@ -112,7 +112,8 @@ class ChainSchema(StructureSchema):
         return new_obj
 
 
-class MoleculeSchema(StructureSchema):
+class MoleculeSchema(Schema):
+    index = fields.Integer(default=-1)
     chains = fields.List(fields.Nested(ChainSchema))
     name = fields.Str()
     associated = fields.Dict()
@@ -133,7 +134,8 @@ class MoleculeSchema(StructureSchema):
         return new_obj
 
 
-class ComplexSchema(StructureSchema):
+class ComplexSchema(Schema):
+    index = fields.Integer(default=-1)
     boxed = fields.Boolean()
     locked = fields.Boolean()
     visible = fields.Boolean()
@@ -168,3 +170,71 @@ class WorkspaceSchema(Schema):
         new_obj = structure.Workspace()
         init_object(new_obj, data)
         return new_obj
+
+
+class StructureSchema(Schema):
+
+    structure_schema_map = {
+        structure.Atom: AtomSchema(),
+        structure.Bond: BondSchema(),
+        structure.Residue: ResidueSchema(),
+        structure.Chain: ChainSchema(),
+        structure.Molecule: MoleculeSchema(),
+        structure.Complex: ComplexSchema(),
+    }
+
+    def determine_structure_schema(self, data):
+        complex_fields = list(ComplexSchema._declared_fields.keys())
+        molecule_fields = list(MoleculeSchema._declared_fields.keys())
+        chain_fields = list(ChainSchema._declared_fields.keys())
+        residue_fields = list(ResidueSchema._declared_fields.keys())
+        atom_fields = list(AtomSchema._declared_fields.keys())
+        bond_fields = list(BondSchema._declared_fields.keys())
+        unique_complex_fields = [
+            field for field in complex_fields
+            if field not in set(molecule_fields + chain_fields + residue_fields + atom_fields + bond_fields)]
+        unique_molecule_fields = [
+            field for field in molecule_fields
+            if field not in set(complex_fields + chain_fields + residue_fields + atom_fields + bond_fields)]
+        unique_chain_fields = [
+            field for field in chain_fields
+            if field not in set(complex_fields + molecule_fields + residue_fields + atom_fields + bond_fields)]
+        unique_residue_fields = [
+            field for field in residue_fields
+            if field not in set(complex_fields + molecule_fields + chain_fields + atom_fields + bond_fields)]
+        unique_bond_fields = [
+            field for field in bond_fields
+            if field not in set(complex_fields + molecule_fields + chain_fields + residue_fields + atom_fields)]
+        unique_atom_fields = [
+            field for field in atom_fields
+            if field not in set(complex_fields + molecule_fields + chain_fields + residue_fields + bond_fields)]
+
+        schema = None
+        if any(data.get(key) for key in unique_complex_fields):
+            schema = ComplexSchema()
+        elif any(data.get(key) for key in unique_molecule_fields):
+            schema = MoleculeSchema()
+        # Shallow versions of chains have no unique values,
+        # so if only name and possibly index is provided, assume its chain data
+        elif any(data.get(key) for key in unique_chain_fields) \
+                or 'name' in data and len(data) <= 2:
+            schema = ChainSchema()
+        elif any(data.get(key) for key in unique_residue_fields):
+            schema = ResidueSchema()
+        elif any(data.get(key) for key in unique_atom_fields):
+            schema = AtomSchema()
+        elif any(data.get(key) for key in unique_bond_fields):
+            schema = BondSchema()
+        if not schema:
+            raise ValueError('Could not determine structure schema')
+        return schema
+
+    def dump(self, obj, *args, **kwargs):
+        obj_class = obj.__class__
+        schema = self.structure_schema_map[obj_class]
+        dump_data = schema.dump(obj, *args, **kwargs)
+        return dump_data
+
+    def load(self, data, *args, **kwargs):
+        correct_schema = self.determine_structure_schema(data)
+        return correct_schema.load(data, *args, **kwargs)

--- a/testing/test_assets/serialized_data/benzene_workspace.json
+++ b/testing/test_assets/serialized_data/benzene_workspace.json
@@ -1,722 +1,1108 @@
-
 {
-
-    "complexes": [
+    "position":
+    [
+        1.6464552879333496,
+        3.194507598876953,
+        -0.5254864692687988
+    ],
+    "scale":
+    [
+        0.039932478219270706,
+        0.039932478219270706,
+        0.039932478219270706
+    ],
+    "rotation":
+    [
+        -0.7636590600013733,
+        0.16238585114479065,
+        -0.3037855625152588,
+        0.5460495948791504
+    ],
+    "complexes":
+    [
         {
-            "box_label": "",
             "boxed": false,
-            "computing": false,
-            "index": 45637813639,
-            "index_tag": 0,
+            "position":
+            [
+                -7.589682102203369,
+                32.121246337890625,
+                -59.71053695678711
+            ],
+            "box_label": "",
+            "current_frame": 0,
+            "rotation":
+            [
+                0.6426494717597961,
+                -0.5729898810386658,
+                -0.4970511198043823,
+                0.10781744122505188
+            ],
             "locked": false,
-            "molecules": [
+            "remarks":
+            {
+                "PUBCHEM_COMPOUND_CID": "",
+                "PUBCHEM_CONFORMER_RMSD": "",
+                "PUBCHEM_CONFORMER_DIVERSEORDER": "",
+                "PUBCHEM_MMFF94_PARTIAL_CHARGES": "",
+                "PUBCHEM_EFFECTIVE_ROTOR_COUNT": "",
+                "PUBCHEM_PHARMACOPHORE_FEATURES": "",
+                "PUBCHEM_HEAVY_ATOM_COUNT": "",
+                "PUBCHEM_ATOM_DEF_STEREO_COUNT": "",
+                "PUBCHEM_ATOM_UDEF_STEREO_COUNT": "",
+                "PUBCHEM_BOND_DEF_STEREO_COUNT": "",
+                "PUBCHEM_BOND_UDEF_STEREO_COUNT": "",
+                "PUBCHEM_ISOTOPIC_ATOM_COUNT": "",
+                "PUBCHEM_COMPONENT_COUNT": "",
+                "PUBCHEM_CACTVS_TAUTO_COUNT": "",
+                "PUBCHEM_CONFORMER_ID": "",
+                "PUBCHEM_MMFF94_ENERGY": "",
+                "PUBCHEM_FEATURE_SELFOVERLAP": "",
+                "PUBCHEM_SHAPE_FINGERPRINT": "",
+                "PUBCHEM_SHAPE_MULTIPOLES": "",
+                "PUBCHEM_SHAPE_SELFOVERLAP": "",
+                "PUBCHEM_SHAPE_VOLUME": "",
+                "PUBCHEM_COORDINATE_TYPE": "",
+                "NAME": "",
+                "Index": "",
+                "Ranking": "0/5",
+                "Notes": ""
+            },
+            "index_tag": 0,
+            "index": 4727331361820,
+            "molecules":
+            [
                 {
-                    "associated": {
-                        "Index": "0",
-                        "NAME": "241",
-                        "PUBCHEM_ATOM_DEF_STEREO_COUNT": "0\n",
-                        "PUBCHEM_ATOM_UDEF_STEREO_COUNT": "0\n",
-                        "PUBCHEM_BOND_DEF_STEREO_COUNT": "0\n",
-                        "PUBCHEM_BOND_UDEF_STEREO_COUNT": "0\n",
-                        "PUBCHEM_CACTVS_TAUTO_COUNT": "1\n",
-                        "PUBCHEM_COMPONENT_COUNT": "1\n",
-                        "PUBCHEM_COMPOUND_CID": "241\n",
-                        "PUBCHEM_CONFORMER_DIVERSEORDER": "1\n",
-                        "PUBCHEM_CONFORMER_ID": "000000F100000001\n",
-                        "PUBCHEM_CONFORMER_RMSD": "0.4\n",
-                        "PUBCHEM_COORDINATE_TYPE": "2\n5\n10\n",
-                        "PUBCHEM_EFFECTIVE_ROTOR_COUNT": "0\n",
-                        "PUBCHEM_FEATURE_SELFOVERLAP": "5.074\n",
-                        "PUBCHEM_HEAVY_ATOM_COUNT": "6\n",
-                        "PUBCHEM_ISOTOPIC_ATOM_COUNT": "0\n",
-                        "PUBCHEM_MMFF94_ENERGY": "13.148\n",
-                        "PUBCHEM_MMFF94_PARTIAL_CHARGES": "12\n1 -0.15\n10 0.15\n11 0.15\n12 0.15\n2 -0.15\n3 -0.15\n4 -0.15\n5 -0.15\n6 -0.15\n7 0.15\n8 0.15\n9 0.15\n",
-                        "PUBCHEM_PHARMACOPHORE_FEATURES": "1\n6 1 2 3 4 5 6 rings\n",
-                        "PUBCHEM_SHAPE_FINGERPRINT": "16714656 1 18123201108121732318\n20096714 4 18339082562313515547\n21015797 1 9222644709913001990\n21040471 1 18194402190896164549\n",
-                        "PUBCHEM_SHAPE_MULTIPOLES": "123.48\n1.59\n1.59\n0.62\n0\n0\n0\n0\n0\n0\n0\n0\n0\n0\n",
-                        "PUBCHEM_SHAPE_SELFOVERLAP": "251.998\n",
-                        "PUBCHEM_SHAPE_VOLUME": "67.5\n"
-                    },
-                    "chains": [
+                    "conformer_count": 1,
+                    "index": 4727422255257,
+                    "chains":
+                    [
                         {
-                            "index": 46578432250,
-                            "name": "S",
-                            "residues": [
+                            "residues":
+                            [
                                 {
-                                    "atoms": [
+                                    "label_text": "",
+                                    "type": "UNK",
+                                    "bonds":
+                                    [
                                         {
-                                            "acceptor": false,
-                                            "alt_loc": "\u0000",
-                                            "atom_color": [
-                                                0,
-                                                0,
-                                                0,
-                                                0
+                                            "in_conformer":
+                                            [
+                                                true
                                             ],
-                                            "atom_mode": 0,
-                                            "atom_rendering": true,
-                                            "atom_scale": 0.5,
-                                            "bfactor": 0.1,
-                                            "donor": false,
-                                            "exists": true,
-                                            "formal_charge": 0,
-                                            "index": 48415221582,
-                                            "is_het": true,
+                                            "kinds":
+                                            [
+                                                2
+                                            ],
+                                            "index": 4730562868097,
+                                            "kind": 2,
+                                            "atom2":
+                                            {
+                                                "index": 4730551089057
+                                            },
+                                            "atom1":
+                                            {
+                                                "index": 4728689485056
+                                            }
+                                        },
+                                        {
+                                            "in_conformer":
+                                            [
+                                                true
+                                            ],
+                                            "kinds":
+                                            [
+                                                1
+                                            ],
+                                            "index": 4732285753908,
+                                            "kind": 1,
+                                            "atom2":
+                                            {
+                                                "index": 4731321201091
+                                            },
+                                            "atom1":
+                                            {
+                                                "index": 4728689485056
+                                            }
+                                        },
+                                        {
+                                            "in_conformer":
+                                            [
+                                                true
+                                            ],
+                                            "kinds":
+                                            [
+                                                1
+                                            ],
+                                            "index": 4733149793414,
+                                            "kind": 1,
+                                            "atom2":
+                                            {
+                                                "index": 4732881131900
+                                            },
+                                            "atom1":
+                                            {
+                                                "index": 4730551089057
+                                            }
+                                        },
+                                        {
+                                            "in_conformer":
+                                            [
+                                                true
+                                            ],
+                                            "kinds":
+                                            [
+                                                2
+                                            ],
+                                            "index": 4734407441326,
+                                            "kind": 2,
+                                            "atom2":
+                                            {
+                                                "index": 4733708751376
+                                            },
+                                            "atom1":
+                                            {
+                                                "index": 4731321201091
+                                            }
+                                        },
+                                        {
+                                            "in_conformer":
+                                            [
+                                                true
+                                            ],
+                                            "kinds":
+                                            [
+                                                2
+                                            ],
+                                            "index": 4736788451397,
+                                            "kind": 2,
+                                            "atom2":
+                                            {
+                                                "index": 4736033631646
+                                            },
+                                            "atom1":
+                                            {
+                                                "index": 4732881131900
+                                            }
+                                        },
+                                        {
+                                            "in_conformer":
+                                            [
+                                                true
+                                            ],
+                                            "kinds":
+                                            [
+                                                1
+                                            ],
+                                            "index": 4736812342776,
+                                            "kind": 1,
+                                            "atom2":
+                                            {
+                                                "index": 4736033631646
+                                            },
+                                            "atom1":
+                                            {
+                                                "index": 4733708751376
+                                            }
+                                        },
+                                        {
+                                            "in_conformer":
+                                            [
+                                                true
+                                            ],
+                                            "kinds":
+                                            [
+                                                1
+                                            ],
+                                            "index": 4737256638055,
+                                            "kind": 1,
+                                            "atom2":
+                                            {
+                                                "index": 4736899938587
+                                            },
+                                            "atom1":
+                                            {
+                                                "index": 4728689485056
+                                            }
+                                        },
+                                        {
+                                            "in_conformer":
+                                            [
+                                                true
+                                            ],
+                                            "kinds":
+                                            [
+                                                1
+                                            ],
+                                            "index": 4738535268780,
+                                            "kind": 1,
+                                            "atom2":
+                                            {
+                                                "index": 4738425782193
+                                            },
+                                            "atom1":
+                                            {
+                                                "index": 4730551089057
+                                            }
+                                        },
+                                        {
+                                            "in_conformer":
+                                            [
+                                                true
+                                            ],
+                                            "kinds":
+                                            [
+                                                1
+                                            ],
+                                            "index": 4739956195738,
+                                            "kind": 1,
+                                            "atom2":
+                                            {
+                                                "index": 4739941399961
+                                            },
+                                            "atom1":
+                                            {
+                                                "index": 4731321201091
+                                            }
+                                        },
+                                        {
+                                            "in_conformer":
+                                            [
+                                                true
+                                            ],
+                                            "kinds":
+                                            [
+                                                1
+                                            ],
+                                            "index": 4740966352533,
+                                            "kind": 1,
+                                            "atom2":
+                                            {
+                                                "index": 4740809466785
+                                            },
+                                            "atom1":
+                                            {
+                                                "index": 4732881131900
+                                            }
+                                        },
+                                        {
+                                            "in_conformer":
+                                            [
+                                                true
+                                            ],
+                                            "kinds":
+                                            [
+                                                1
+                                            ],
+                                            "index": 4741780013903,
+                                            "kind": 1,
+                                            "atom2":
+                                            {
+                                                "index": 4741760822628
+                                            },
+                                            "atom1":
+                                            {
+                                                "index": 4733708751376
+                                            }
+                                        },
+                                        {
+                                            "in_conformer":
+                                            [
+                                                true
+                                            ],
+                                            "kinds":
+                                            [
+                                                1
+                                            ],
+                                            "index": 4743265325815,
+                                            "kind": 1,
+                                            "atom2":
+                                            {
+                                                "index": 4742381687971
+                                            },
+                                            "atom1":
+                                            {
+                                                "index": 4736033631646
+                                            }
+                                        }
+                                    ],
+                                    "atoms":
+                                    [
+                                        {
                                             "label_text": "",
-                                            "labeled": false,
-                                            "name": "C",
-                                            "occupancy": 0.1,
-                                            "partial_charge": 0.0,
-                                            "polar_hydrogen": false,
-                                            "position": [
-                                                -1.2130999565124512,
-                                                -0.6883999705314636,
-                                                0.0
-                                            ],
-                                            "positions": [
+                                            "positions":
+                                            [
                                                 [
                                                     -1.2130999565124512,
                                                     -0.6883999705314636,
                                                     0.0
                                                 ]
                                             ],
-                                            "selected": false,
-                                            "serial": 1,
-                                            "surface_color": [
+                                            "atom_mode": 0,
+                                            "bfactor": 0.0,
+                                            "position":
+                                            [
+                                                -1.2130999565124512,
+                                                -0.6883999705314636,
+                                                0.0
+                                            ],
+                                            "partial_charge": 0.0,
+                                            "atom_scale": 0.5,
+                                            "formal_charge": 0,
+                                            "labeled": false,
+                                            "atom_color":
+                                            [
                                                 0,
                                                 0,
                                                 0,
                                                 0
                                             ],
+                                            "polar_hydrogen": false,
+                                            "acceptor": false,
+                                            "atom_rendering": true,
+                                            "is_het": true,
                                             "surface_rendering": false,
-                                            "symbol": "C"
+                                            "alt_loc": "\u0000",
+                                            "occupancy": 1.0,
+                                            "in_conformer":
+                                            [
+                                                true
+                                            ],
+                                            "serial": 1,
+                                            "surface_opacity": 0.75,
+                                            "name": "C",
+                                            "symbol": "C",
+                                            "donor": false,
+                                            "surface_color":
+                                            [
+                                                0,
+                                                0,
+                                                0,
+                                                0
+                                            ],
+                                            "exists": true,
+                                            "index": 4728689485056,
+                                            "selected": true,
+                                            "het_surfaced": false
                                         },
                                         {
-                                            "acceptor": false,
-                                            "alt_loc": "\u0000",
-                                            "atom_color": [
-                                                0,
-                                                0,
-                                                0,
-                                                0
-                                            ],
-                                            "atom_mode": 0,
-                                            "atom_rendering": true,
-                                            "atom_scale": 0.5,
-                                            "bfactor": 0.1,
-                                            "donor": false,
-                                            "exists": true,
-                                            "formal_charge": 0,
-                                            "index": 49238375095,
-                                            "is_het": true,
                                             "label_text": "",
-                                            "labeled": false,
-                                            "name": "C",
-                                            "occupancy": 0.1,
-                                            "partial_charge": 0.0,
-                                            "polar_hydrogen": false,
-                                            "position": [
-                                                -1.2028000354766846,
-                                                0.7063999772071838,
-                                                9.999999747378752e-05
-                                            ],
-                                            "positions": [
+                                            "positions":
+                                            [
                                                 [
                                                     -1.2028000354766846,
                                                     0.7063999772071838,
-                                                    9.999999747378752e-05
+                                                    0.00009999999747378752
                                                 ]
                                             ],
-                                            "selected": false,
-                                            "serial": 2,
-                                            "surface_color": [
+                                            "atom_mode": 0,
+                                            "bfactor": 0.0,
+                                            "position":
+                                            [
+                                                -1.2028000354766846,
+                                                0.7063999772071838,
+                                                0.00009999999747378752
+                                            ],
+                                            "partial_charge": 0.0,
+                                            "atom_scale": 0.5,
+                                            "formal_charge": 0,
+                                            "labeled": false,
+                                            "atom_color":
+                                            [
                                                 0,
                                                 0,
                                                 0,
                                                 0
                                             ],
+                                            "polar_hydrogen": false,
+                                            "acceptor": false,
+                                            "atom_rendering": true,
+                                            "is_het": true,
                                             "surface_rendering": false,
-                                            "symbol": "C"
+                                            "alt_loc": "\u0000",
+                                            "occupancy": 1.0,
+                                            "in_conformer":
+                                            [
+                                                true
+                                            ],
+                                            "serial": 2,
+                                            "surface_opacity": 0.75,
+                                            "name": "C",
+                                            "symbol": "C",
+                                            "donor": false,
+                                            "surface_color":
+                                            [
+                                                0,
+                                                0,
+                                                0,
+                                                0
+                                            ],
+                                            "exists": true,
+                                            "index": 4730551089057,
+                                            "selected": true,
+                                            "het_surfaced": false
                                         },
                                         {
-                                            "acceptor": false,
-                                            "alt_loc": "\u0000",
-                                            "atom_color": [
-                                                0,
-                                                0,
-                                                0,
-                                                0
-                                            ],
-                                            "atom_mode": 0,
-                                            "atom_rendering": true,
-                                            "atom_scale": 0.5,
-                                            "bfactor": 0.1,
-                                            "donor": false,
-                                            "exists": true,
-                                            "formal_charge": 0,
-                                            "index": 50197100433,
-                                            "is_het": true,
                                             "label_text": "",
-                                            "labeled": false,
-                                            "name": "C",
-                                            "occupancy": 0.1,
-                                            "partial_charge": 0.0,
-                                            "polar_hydrogen": false,
-                                            "position": [
-                                                -0.010300000198185444,
-                                                -1.3947999477386475,
-                                                0.0
-                                            ],
-                                            "positions": [
+                                            "positions":
+                                            [
                                                 [
                                                     -0.010300000198185444,
                                                     -1.3947999477386475,
                                                     0.0
                                                 ]
                                             ],
-                                            "selected": false,
-                                            "serial": 3,
-                                            "surface_color": [
+                                            "atom_mode": 0,
+                                            "bfactor": 0.0,
+                                            "position":
+                                            [
+                                                -0.010300000198185444,
+                                                -1.3947999477386475,
+                                                0.0
+                                            ],
+                                            "partial_charge": 0.0,
+                                            "atom_scale": 0.5,
+                                            "formal_charge": 0,
+                                            "labeled": false,
+                                            "atom_color":
+                                            [
                                                 0,
                                                 0,
                                                 0,
                                                 0
                                             ],
+                                            "polar_hydrogen": false,
+                                            "acceptor": false,
+                                            "atom_rendering": true,
+                                            "is_het": true,
                                             "surface_rendering": false,
-                                            "symbol": "C"
+                                            "alt_loc": "\u0000",
+                                            "occupancy": 1.0,
+                                            "in_conformer":
+                                            [
+                                                true
+                                            ],
+                                            "serial": 3,
+                                            "surface_opacity": 0.75,
+                                            "name": "C",
+                                            "symbol": "C",
+                                            "donor": false,
+                                            "surface_color":
+                                            [
+                                                0,
+                                                0,
+                                                0,
+                                                0
+                                            ],
+                                            "exists": true,
+                                            "index": 4731321201091,
+                                            "selected": true,
+                                            "het_surfaced": false
                                         },
                                         {
-                                            "acceptor": false,
-                                            "alt_loc": "\u0000",
-                                            "atom_color": [
-                                                0,
-                                                0,
-                                                0,
-                                                0
-                                            ],
-                                            "atom_mode": 0,
-                                            "atom_rendering": true,
-                                            "atom_scale": 0.5,
-                                            "bfactor": 0.1,
-                                            "donor": false,
-                                            "exists": true,
-                                            "formal_charge": 0,
-                                            "index": 51013915067,
-                                            "is_het": true,
                                             "label_text": "",
-                                            "labeled": false,
-                                            "name": "C",
-                                            "occupancy": 0.1,
-                                            "partial_charge": 0.0,
-                                            "polar_hydrogen": false,
-                                            "position": [
-                                                0.010400000028312206,
-                                                1.3947999477386475,
-                                                -9.999999747378752e-05
-                                            ],
-                                            "positions": [
+                                            "positions":
+                                            [
                                                 [
                                                     0.010400000028312206,
                                                     1.3947999477386475,
-                                                    -9.999999747378752e-05
+                                                    -0.00009999999747378752
                                                 ]
                                             ],
-                                            "selected": false,
-                                            "serial": 4,
-                                            "surface_color": [
+                                            "atom_mode": 0,
+                                            "bfactor": 0.0,
+                                            "position":
+                                            [
+                                                0.010400000028312206,
+                                                1.3947999477386475,
+                                                -0.00009999999747378752
+                                            ],
+                                            "partial_charge": 0.0,
+                                            "atom_scale": 0.5,
+                                            "formal_charge": 0,
+                                            "labeled": false,
+                                            "atom_color":
+                                            [
                                                 0,
                                                 0,
                                                 0,
                                                 0
                                             ],
+                                            "polar_hydrogen": false,
+                                            "acceptor": false,
+                                            "atom_rendering": true,
+                                            "is_het": true,
                                             "surface_rendering": false,
-                                            "symbol": "C"
+                                            "alt_loc": "\u0000",
+                                            "occupancy": 1.0,
+                                            "in_conformer":
+                                            [
+                                                true
+                                            ],
+                                            "serial": 4,
+                                            "surface_opacity": 0.75,
+                                            "name": "C",
+                                            "symbol": "C",
+                                            "donor": false,
+                                            "surface_color":
+                                            [
+                                                0,
+                                                0,
+                                                0,
+                                                0
+                                            ],
+                                            "exists": true,
+                                            "index": 4732881131900,
+                                            "selected": true,
+                                            "het_surfaced": false
                                         },
                                         {
-                                            "acceptor": false,
-                                            "alt_loc": "\u0000",
-                                            "atom_color": [
-                                                0,
-                                                0,
-                                                0,
-                                                0
-                                            ],
-                                            "atom_mode": 0,
-                                            "atom_rendering": true,
-                                            "atom_scale": 0.5,
-                                            "bfactor": 0.1,
-                                            "donor": false,
-                                            "exists": true,
-                                            "formal_charge": 0,
-                                            "index": 52085776824,
-                                            "is_het": true,
                                             "label_text": "",
-                                            "labeled": false,
-                                            "name": "C",
-                                            "occupancy": 0.1,
-                                            "partial_charge": 0.0,
-                                            "polar_hydrogen": false,
-                                            "position": [
-                                                1.2028000354766846,
-                                                -0.7063000202178955,
-                                                0.0
-                                            ],
-                                            "positions": [
+                                            "positions":
+                                            [
                                                 [
                                                     1.2028000354766846,
                                                     -0.7063000202178955,
                                                     0.0
                                                 ]
                                             ],
-                                            "selected": false,
-                                            "serial": 5,
-                                            "surface_color": [
-                                                0,
-                                                0,
-                                                0,
-                                                0
-                                            ],
-                                            "surface_rendering": false,
-                                            "symbol": "C"
-                                        },
-                                        {
-                                            "acceptor": false,
-                                            "alt_loc": "\u0000",
-                                            "atom_color": [
-                                                0,
-                                                0,
-                                                0,
-                                                0
-                                            ],
                                             "atom_mode": 0,
-                                            "atom_rendering": true,
-                                            "atom_scale": 0.5,
-                                            "bfactor": 0.1,
-                                            "donor": false,
-                                            "exists": true,
-                                            "formal_charge": 0,
-                                            "index": 54135415253,
-                                            "is_het": true,
-                                            "label_text": "",
-                                            "labeled": false,
-                                            "name": "C",
-                                            "occupancy": 0.1,
-                                            "partial_charge": 0.0,
-                                            "polar_hydrogen": false,
-                                            "position": [
-                                                1.2130999565124512,
-                                                0.6883999705314636,
+                                            "bfactor": 0.0,
+                                            "position":
+                                            [
+                                                1.2028000354766846,
+                                                -0.7063000202178955,
                                                 0.0
                                             ],
-                                            "positions": [
+                                            "partial_charge": 0.0,
+                                            "atom_scale": 0.5,
+                                            "formal_charge": 0,
+                                            "labeled": false,
+                                            "atom_color":
+                                            [
+                                                0,
+                                                0,
+                                                0,
+                                                0
+                                            ],
+                                            "polar_hydrogen": false,
+                                            "acceptor": false,
+                                            "atom_rendering": true,
+                                            "is_het": true,
+                                            "surface_rendering": false,
+                                            "alt_loc": "\u0000",
+                                            "occupancy": 1.0,
+                                            "in_conformer":
+                                            [
+                                                true
+                                            ],
+                                            "serial": 5,
+                                            "surface_opacity": 0.75,
+                                            "name": "C",
+                                            "symbol": "C",
+                                            "donor": false,
+                                            "surface_color":
+                                            [
+                                                0,
+                                                0,
+                                                0,
+                                                0
+                                            ],
+                                            "exists": true,
+                                            "index": 4733708751376,
+                                            "selected": true,
+                                            "het_surfaced": false
+                                        },
+                                        {
+                                            "label_text": "",
+                                            "positions":
+                                            [
                                                 [
                                                     1.2130999565124512,
                                                     0.6883999705314636,
                                                     0.0
                                                 ]
                                             ],
-                                            "selected": false,
-                                            "serial": 6,
-                                            "surface_color": [
-                                                0,
-                                                0,
-                                                0,
-                                                0
-                                            ],
-                                            "surface_rendering": false,
-                                            "symbol": "C"
-                                        },
-                                        {
-                                            "acceptor": false,
-                                            "alt_loc": "\u0000",
-                                            "atom_color": [
-                                                0,
-                                                0,
-                                                0,
-                                                0
-                                            ],
                                             "atom_mode": 0,
-                                            "atom_rendering": true,
-                                            "atom_scale": 0.5,
-                                            "bfactor": 0.1,
-                                            "donor": false,
-                                            "exists": true,
-                                            "formal_charge": 0,
-                                            "index": 55000758929,
-                                            "is_het": true,
-                                            "label_text": "",
-                                            "labeled": false,
-                                            "name": "H",
-                                            "occupancy": 0.1,
-                                            "partial_charge": 0.0,
-                                            "polar_hydrogen": false,
-                                            "position": [
-                                                -2.1577000617980957,
-                                                -1.2244000434875488,
+                                            "bfactor": 0.0,
+                                            "position":
+                                            [
+                                                1.2130999565124512,
+                                                0.6883999705314636,
                                                 0.0
                                             ],
-                                            "positions": [
+                                            "partial_charge": 0.0,
+                                            "atom_scale": 0.5,
+                                            "formal_charge": 0,
+                                            "labeled": false,
+                                            "atom_color":
+                                            [
+                                                0,
+                                                0,
+                                                0,
+                                                0
+                                            ],
+                                            "polar_hydrogen": false,
+                                            "acceptor": false,
+                                            "atom_rendering": true,
+                                            "is_het": true,
+                                            "surface_rendering": false,
+                                            "alt_loc": "\u0000",
+                                            "occupancy": 1.0,
+                                            "in_conformer":
+                                            [
+                                                true
+                                            ],
+                                            "serial": 6,
+                                            "surface_opacity": 0.75,
+                                            "name": "C",
+                                            "symbol": "C",
+                                            "donor": false,
+                                            "surface_color":
+                                            [
+                                                0,
+                                                0,
+                                                0,
+                                                0
+                                            ],
+                                            "exists": true,
+                                            "index": 4736033631646,
+                                            "selected": true,
+                                            "het_surfaced": false
+                                        },
+                                        {
+                                            "label_text": "",
+                                            "positions":
+                                            [
                                                 [
                                                     -2.1577000617980957,
                                                     -1.2244000434875488,
                                                     0.0
                                                 ]
                                             ],
-                                            "selected": false,
-                                            "serial": 7,
-                                            "surface_color": [
+                                            "atom_mode": 0,
+                                            "bfactor": 0.0,
+                                            "position":
+                                            [
+                                                -2.1577000617980957,
+                                                -1.2244000434875488,
+                                                0.0
+                                            ],
+                                            "partial_charge": 0.0,
+                                            "atom_scale": 0.5,
+                                            "formal_charge": 0,
+                                            "labeled": false,
+                                            "atom_color":
+                                            [
                                                 0,
                                                 0,
                                                 0,
                                                 0
                                             ],
+                                            "polar_hydrogen": false,
+                                            "acceptor": false,
+                                            "atom_rendering": true,
+                                            "is_het": true,
                                             "surface_rendering": false,
-                                            "symbol": "H"
+                                            "alt_loc": "\u0000",
+                                            "occupancy": 1.0,
+                                            "in_conformer":
+                                            [
+                                                true
+                                            ],
+                                            "serial": 7,
+                                            "surface_opacity": 0.75,
+                                            "name": "H",
+                                            "symbol": "H",
+                                            "donor": false,
+                                            "surface_color":
+                                            [
+                                                0,
+                                                0,
+                                                0,
+                                                0
+                                            ],
+                                            "exists": true,
+                                            "index": 4736899938587,
+                                            "selected": true,
+                                            "het_surfaced": false
                                         },
                                         {
-                                            "acceptor": false,
-                                            "alt_loc": "\u0000",
-                                            "atom_color": [
-                                                0,
-                                                0,
-                                                0,
-                                                0
-                                            ],
-                                            "atom_mode": 0,
-                                            "atom_rendering": true,
-                                            "atom_scale": 0.5,
-                                            "bfactor": 0.1,
-                                            "donor": false,
-                                            "exists": true,
-                                            "formal_charge": 0,
-                                            "index": 56475937472,
-                                            "is_het": true,
                                             "label_text": "",
-                                            "labeled": false,
-                                            "name": "H",
-                                            "occupancy": 0.1,
-                                            "partial_charge": 0.0,
-                                            "polar_hydrogen": false,
-                                            "position": [
-                                                -2.1393001079559326,
-                                                1.2563999891281128,
-                                                9.999999747378752e-05
-                                            ],
-                                            "positions": [
+                                            "positions":
+                                            [
                                                 [
                                                     -2.1393001079559326,
                                                     1.2563999891281128,
-                                                    9.999999747378752e-05
+                                                    0.00009999999747378752
                                                 ]
                                             ],
-                                            "selected": false,
-                                            "serial": 8,
-                                            "surface_color": [
+                                            "atom_mode": 0,
+                                            "bfactor": 0.0,
+                                            "position":
+                                            [
+                                                -2.1393001079559326,
+                                                1.2563999891281128,
+                                                0.00009999999747378752
+                                            ],
+                                            "partial_charge": 0.0,
+                                            "atom_scale": 0.5,
+                                            "formal_charge": 0,
+                                            "labeled": false,
+                                            "atom_color":
+                                            [
                                                 0,
                                                 0,
                                                 0,
                                                 0
                                             ],
+                                            "polar_hydrogen": false,
+                                            "acceptor": false,
+                                            "atom_rendering": true,
+                                            "is_het": true,
                                             "surface_rendering": false,
-                                            "symbol": "H"
+                                            "alt_loc": "\u0000",
+                                            "occupancy": 1.0,
+                                            "in_conformer":
+                                            [
+                                                true
+                                            ],
+                                            "serial": 8,
+                                            "surface_opacity": 0.75,
+                                            "name": "H",
+                                            "symbol": "H",
+                                            "donor": false,
+                                            "surface_color":
+                                            [
+                                                0,
+                                                0,
+                                                0,
+                                                0
+                                            ],
+                                            "exists": true,
+                                            "index": 4738425782193,
+                                            "selected": true,
+                                            "het_surfaced": false
                                         },
                                         {
-                                            "acceptor": false,
-                                            "alt_loc": "\u0000",
-                                            "atom_color": [
-                                                0,
-                                                0,
-                                                0,
-                                                0
-                                            ],
-                                            "atom_mode": 0,
-                                            "atom_rendering": true,
-                                            "atom_scale": 0.5,
-                                            "bfactor": 0.1,
-                                            "donor": false,
-                                            "exists": true,
-                                            "formal_charge": 0,
-                                            "index": 57191868478,
-                                            "is_het": true,
                                             "label_text": "",
-                                            "labeled": false,
-                                            "name": "H",
-                                            "occupancy": 0.1,
-                                            "partial_charge": 0.0,
-                                            "polar_hydrogen": false,
-                                            "position": [
-                                                -0.018400000408291817,
-                                                -2.4809000492095947,
-                                                -9.999999747378752e-05
-                                            ],
-                                            "positions": [
+                                            "positions":
+                                            [
                                                 [
                                                     -0.018400000408291817,
                                                     -2.4809000492095947,
-                                                    -9.999999747378752e-05
+                                                    -0.00009999999747378752
                                                 ]
                                             ],
-                                            "selected": false,
-                                            "serial": 9,
-                                            "surface_color": [
+                                            "atom_mode": 0,
+                                            "bfactor": 0.0,
+                                            "position":
+                                            [
+                                                -0.018400000408291817,
+                                                -2.4809000492095947,
+                                                -0.00009999999747378752
+                                            ],
+                                            "partial_charge": 0.0,
+                                            "atom_scale": 0.5,
+                                            "formal_charge": 0,
+                                            "labeled": false,
+                                            "atom_color":
+                                            [
                                                 0,
                                                 0,
                                                 0,
                                                 0
                                             ],
+                                            "polar_hydrogen": false,
+                                            "acceptor": false,
+                                            "atom_rendering": true,
+                                            "is_het": true,
                                             "surface_rendering": false,
-                                            "symbol": "H"
+                                            "alt_loc": "\u0000",
+                                            "occupancy": 1.0,
+                                            "in_conformer":
+                                            [
+                                                true
+                                            ],
+                                            "serial": 9,
+                                            "surface_opacity": 0.75,
+                                            "name": "H",
+                                            "symbol": "H",
+                                            "donor": false,
+                                            "surface_color":
+                                            [
+                                                0,
+                                                0,
+                                                0,
+                                                0
+                                            ],
+                                            "exists": true,
+                                            "index": 4739941399961,
+                                            "selected": true,
+                                            "het_surfaced": false
                                         },
                                         {
-                                            "acceptor": false,
-                                            "alt_loc": "\u0000",
-                                            "atom_color": [
-                                                0,
-                                                0,
-                                                0,
-                                                0
-                                            ],
-                                            "atom_mode": 0,
-                                            "atom_rendering": true,
-                                            "atom_scale": 0.5,
-                                            "bfactor": 0.1,
-                                            "donor": false,
-                                            "exists": true,
-                                            "formal_charge": 0,
-                                            "index": 59101746998,
-                                            "is_het": true,
                                             "label_text": "",
-                                            "labeled": false,
-                                            "name": "H",
-                                            "occupancy": 0.1,
-                                            "partial_charge": 0.0,
-                                            "polar_hydrogen": false,
-                                            "position": [
-                                                0.018400000408291817,
-                                                2.480799913406372,
-                                                0.0
-                                            ],
-                                            "positions": [
+                                            "positions":
+                                            [
                                                 [
                                                     0.018400000408291817,
                                                     2.480799913406372,
                                                     0.0
                                                 ]
                                             ],
-                                            "selected": false,
-                                            "serial": 10,
-                                            "surface_color": [
+                                            "atom_mode": 0,
+                                            "bfactor": 0.0,
+                                            "position":
+                                            [
+                                                0.018400000408291817,
+                                                2.480799913406372,
+                                                0.0
+                                            ],
+                                            "partial_charge": 0.0,
+                                            "atom_scale": 0.5,
+                                            "formal_charge": 0,
+                                            "labeled": false,
+                                            "atom_color":
+                                            [
                                                 0,
                                                 0,
                                                 0,
                                                 0
                                             ],
+                                            "polar_hydrogen": false,
+                                            "acceptor": false,
+                                            "atom_rendering": true,
+                                            "is_het": true,
                                             "surface_rendering": false,
-                                            "symbol": "H"
+                                            "alt_loc": "\u0000",
+                                            "occupancy": 1.0,
+                                            "in_conformer":
+                                            [
+                                                true
+                                            ],
+                                            "serial": 10,
+                                            "surface_opacity": 0.75,
+                                            "name": "H",
+                                            "symbol": "H",
+                                            "donor": false,
+                                            "surface_color":
+                                            [
+                                                0,
+                                                0,
+                                                0,
+                                                0
+                                            ],
+                                            "exists": true,
+                                            "index": 4740809466785,
+                                            "selected": true,
+                                            "het_surfaced": false
                                         },
                                         {
-                                            "acceptor": false,
-                                            "alt_loc": "\u0000",
-                                            "atom_color": [
-                                                0,
-                                                0,
-                                                0,
-                                                0
-                                            ],
-                                            "atom_mode": 0,
-                                            "atom_rendering": true,
-                                            "atom_scale": 0.5,
-                                            "bfactor": 0.1,
-                                            "donor": false,
-                                            "exists": true,
-                                            "formal_charge": 0,
-                                            "index": 59607862656,
-                                            "is_het": true,
                                             "label_text": "",
-                                            "labeled": false,
-                                            "name": "H",
-                                            "occupancy": 0.1,
-                                            "partial_charge": 0.0,
-                                            "polar_hydrogen": false,
-                                            "position": [
-                                                2.139400005340576,
-                                                -1.2562999725341797,
-                                                9.999999747378752e-05
-                                            ],
-                                            "positions": [
+                                            "positions":
+                                            [
                                                 [
                                                     2.139400005340576,
                                                     -1.2562999725341797,
-                                                    9.999999747378752e-05
+                                                    0.00009999999747378752
                                                 ]
                                             ],
-                                            "selected": false,
-                                            "serial": 11,
-                                            "surface_color": [
+                                            "atom_mode": 0,
+                                            "bfactor": 0.0,
+                                            "position":
+                                            [
+                                                2.139400005340576,
+                                                -1.2562999725341797,
+                                                0.00009999999747378752
+                                            ],
+                                            "partial_charge": 0.0,
+                                            "atom_scale": 0.5,
+                                            "formal_charge": 0,
+                                            "labeled": false,
+                                            "atom_color":
+                                            [
                                                 0,
                                                 0,
                                                 0,
                                                 0
                                             ],
+                                            "polar_hydrogen": false,
+                                            "acceptor": false,
+                                            "atom_rendering": true,
+                                            "is_het": true,
                                             "surface_rendering": false,
-                                            "symbol": "H"
+                                            "alt_loc": "\u0000",
+                                            "occupancy": 1.0,
+                                            "in_conformer":
+                                            [
+                                                true
+                                            ],
+                                            "serial": 11,
+                                            "surface_opacity": 0.75,
+                                            "name": "H",
+                                            "symbol": "H",
+                                            "donor": false,
+                                            "surface_color":
+                                            [
+                                                0,
+                                                0,
+                                                0,
+                                                0
+                                            ],
+                                            "exists": true,
+                                            "index": 4741760822628,
+                                            "selected": true,
+                                            "het_surfaced": false
                                         },
                                         {
-                                            "acceptor": false,
-                                            "alt_loc": "\u0000",
-                                            "atom_color": [
-                                                0,
-                                                0,
-                                                0,
-                                                0
-                                            ],
-                                            "atom_mode": 0,
-                                            "atom_rendering": true,
-                                            "atom_scale": 0.5,
-                                            "bfactor": 0.1,
-                                            "donor": false,
-                                            "exists": true,
-                                            "formal_charge": 0,
-                                            "index": 60122755059,
-                                            "is_het": true,
                                             "label_text": "",
-                                            "labeled": false,
-                                            "name": "H",
-                                            "occupancy": 0.1,
-                                            "partial_charge": 0.0,
-                                            "polar_hydrogen": false,
-                                            "position": [
-                                                2.1577000617980957,
-                                                1.2244999408721924,
-                                                0.0
-                                            ],
-                                            "positions": [
+                                            "positions":
+                                            [
                                                 [
                                                     2.1577000617980957,
                                                     1.2244999408721924,
                                                     0.0
                                                 ]
                                             ],
-                                            "selected": false,
-                                            "serial": 12,
-                                            "surface_color": [
+                                            "atom_mode": 0,
+                                            "bfactor": 0.0,
+                                            "position":
+                                            [
+                                                2.1577000617980957,
+                                                1.2244999408721924,
+                                                0.0
+                                            ],
+                                            "partial_charge": 0.0,
+                                            "atom_scale": 0.5,
+                                            "formal_charge": 0,
+                                            "labeled": false,
+                                            "atom_color":
+                                            [
                                                 0,
                                                 0,
                                                 0,
                                                 0
                                             ],
+                                            "polar_hydrogen": false,
+                                            "acceptor": false,
+                                            "atom_rendering": true,
+                                            "is_het": true,
                                             "surface_rendering": false,
-                                            "symbol": "H"
+                                            "alt_loc": "\u0000",
+                                            "occupancy": 1.0,
+                                            "in_conformer":
+                                            [
+                                                true
+                                            ],
+                                            "serial": 12,
+                                            "surface_opacity": 0.75,
+                                            "name": "H",
+                                            "symbol": "H",
+                                            "donor": false,
+                                            "surface_color":
+                                            [
+                                                0,
+                                                0,
+                                                0,
+                                                0
+                                            ],
+                                            "exists": true,
+                                            "index": 4742381687971,
+                                            "selected": true,
+                                            "het_surfaced": false
                                         }
                                     ],
-                                    "bonds": [
-                                        {
-                                            "index": 50017216354,
-                                            "kind": 2
-                                        },
-                                        {
-                                            "index": 50302080736,
-                                            "kind": 1
-                                        },
-                                        {
-                                            "index": 51044454970,
-                                            "kind": 1
-                                        },
-                                        {
-                                            "index": 52883757021,
-                                            "kind": 2
-                                        },
-                                        {
-                                            "index": 54331604914,
-                                            "kind": 2
-                                        },
-                                        {
-                                            "index": 54903197672,
-                                            "kind": 1
-                                        },
-                                        {
-                                            "index": 55751315414,
-                                            "kind": 1
-                                        },
-                                        {
-                                            "index": 56955815048,
-                                            "kind": 1
-                                        },
-                                        {
-                                            "index": 58171164906,
-                                            "kind": 1
-                                        },
-                                        {
-                                            "index": 59321909499,
-                                            "kind": 1
-                                        },
-                                        {
-                                            "index": 59752564705,
-                                            "kind": 1
-                                        },
-                                        {
-                                            "index": 60494865512,
-                                            "kind": 1
-                                        }
-                                    ],
-                                    "ignored_alt_locs": [ ],
-                                    "index": 46951513954,
-                                    "label_text": "",
+                                    "serial": 1,
+                                    "secondary_structure": 0,
+                                    "ignored_alt_locs":
+                                    [],
+                                    "ribbon_mode": 0,
                                     "labeled": false,
-                                    "name": "SDF",
-                                    "ribbon_color": [
+                                    "index": 4728315250488,
+                                    "ribboned": true,
+                                    "ribbon_size": 1.0,
+                                    "ribbon_color":
+                                    [
                                         0,
                                         0,
                                         0,
                                         0
                                     ],
-                                    "ribbon_mode": 0,
-                                    "ribbon_size": 1.0,
-                                    "ribboned": true,
-                                    "secondary_structure": 0,
-                                    "serial": 1,
-                                    "type": "UNK"
+                                    "name": "SDF"
                                 }
-                            ]
+                            ],
+                            "index": 4728202129851,
+                            "name": "S"
                         }
                     ],
+                    "associated":
+                    {
+                        "PUBCHEM_COMPOUND_CID": "241\n",
+                        "PUBCHEM_CONFORMER_RMSD": "0.4\n",
+                        "PUBCHEM_CONFORMER_DIVERSEORDER": "1\n",
+                        "PUBCHEM_MMFF94_PARTIAL_CHARGES": "12\n1 -0.15\n10 0.15\n11 0.15\n12 0.15\n2 -0.15\n3 -0.15\n4 -0.15\n5 -0.15\n6 -0.15\n7 0.15\n8 0.15\n9 0.15\n",
+                        "PUBCHEM_EFFECTIVE_ROTOR_COUNT": "0\n",
+                        "PUBCHEM_PHARMACOPHORE_FEATURES": "1\n6 1 2 3 4 5 6 rings\n",
+                        "PUBCHEM_HEAVY_ATOM_COUNT": "6\n",
+                        "PUBCHEM_ATOM_DEF_STEREO_COUNT": "0\n",
+                        "PUBCHEM_ATOM_UDEF_STEREO_COUNT": "0\n",
+                        "PUBCHEM_BOND_DEF_STEREO_COUNT": "0\n",
+                        "PUBCHEM_BOND_UDEF_STEREO_COUNT": "0\n",
+                        "PUBCHEM_ISOTOPIC_ATOM_COUNT": "0\n",
+                        "PUBCHEM_COMPONENT_COUNT": "1\n",
+                        "PUBCHEM_CACTVS_TAUTO_COUNT": "1\n",
+                        "PUBCHEM_CONFORMER_ID": "000000F100000001\n",
+                        "PUBCHEM_MMFF94_ENERGY": "13.148\n",
+                        "PUBCHEM_FEATURE_SELFOVERLAP": "5.074\n",
+                        "PUBCHEM_SHAPE_FINGERPRINT": "16714656 1 18123201108121732318\n20096714 4 18339082562313515547\n21015797 1 9222644709913001990\n21040471 1 18194402190896164549\n",
+                        "PUBCHEM_SHAPE_MULTIPOLES": "123.48\n1.59\n1.59\n0.62\n0\n0\n0\n0\n0\n0\n0\n0\n0\n0\n",
+                        "PUBCHEM_SHAPE_SELFOVERLAP": "251.998\n",
+                        "PUBCHEM_SHAPE_VOLUME": "67.5\n",
+                        "PUBCHEM_COORDINATE_TYPE": "2\n5\n10\n",
+                        "NAME": "241",
+                        "Index": "0"
+                    },
                     "current_conformer": 0,
-                    "index": 46069526281,
-                    "name": "241",
-                    "conformer_count": 1
+                    "associateds":
+                    [
+                        {
+                            "PUBCHEM_COMPOUND_CID": "241\n",
+                            "PUBCHEM_CONFORMER_RMSD": "0.4\n",
+                            "PUBCHEM_CONFORMER_DIVERSEORDER": "1\n",
+                            "PUBCHEM_MMFF94_PARTIAL_CHARGES": "12\n1 -0.15\n10 0.15\n11 0.15\n12 0.15\n2 -0.15\n3 -0.15\n4 -0.15\n5 -0.15\n6 -0.15\n7 0.15\n8 0.15\n9 0.15\n",
+                            "PUBCHEM_EFFECTIVE_ROTOR_COUNT": "0\n",
+                            "PUBCHEM_PHARMACOPHORE_FEATURES": "1\n6 1 2 3 4 5 6 rings\n",
+                            "PUBCHEM_HEAVY_ATOM_COUNT": "6\n",
+                            "PUBCHEM_ATOM_DEF_STEREO_COUNT": "0\n",
+                            "PUBCHEM_ATOM_UDEF_STEREO_COUNT": "0\n",
+                            "PUBCHEM_BOND_DEF_STEREO_COUNT": "0\n",
+                            "PUBCHEM_BOND_UDEF_STEREO_COUNT": "0\n",
+                            "PUBCHEM_ISOTOPIC_ATOM_COUNT": "0\n",
+                            "PUBCHEM_COMPONENT_COUNT": "1\n",
+                            "PUBCHEM_CACTVS_TAUTO_COUNT": "1\n",
+                            "PUBCHEM_CONFORMER_ID": "000000F100000001\n",
+                            "PUBCHEM_MMFF94_ENERGY": "13.148\n",
+                            "PUBCHEM_FEATURE_SELFOVERLAP": "5.074\n",
+                            "PUBCHEM_SHAPE_FINGERPRINT": "16714656 1 18123201108121732318\n20096714 4 18339082562313515547\n21015797 1 9222644709913001990\n21040471 1 18194402190896164549\n",
+                            "PUBCHEM_SHAPE_MULTIPOLES": "123.48\n1.59\n1.59\n0.62\n0\n0\n0\n0\n0\n0\n0\n0\n0\n0\n",
+                            "PUBCHEM_SHAPE_SELFOVERLAP": "251.998\n",
+                            "PUBCHEM_SHAPE_VOLUME": "67.5\n",
+                            "PUBCHEM_COORDINATE_TYPE": "2\n5\n10\n",
+                            "NAME": "241",
+                            "Index": "0"
+                        }
+                    ],
+                    "names":
+                    [
+                        "241"
+                    ],
+                    "name": "241"
                 }
             ],
-            "name": "241",
-            "position": [
-                1.887488724605646e-05,
-                4.899984836578369,
-                -50.00040817260742
-            ],
-            "rotation": [
-                2.1854731566128827e-11,
-                -0.9999995231628418,
-                -0.0009999561589211226,
-                -2.1855688814298446e-08
-            ],
+            "visible": true,
             "split_tag": "",
-            "visible": true
+            "computing": false,
+            "name": "241"
         }
-    ],
-    "position": [
-        -0.0,
-        1.2999999523162842,
-        0.0
-    ],
-    "rotation": [
-        -0.0,
-        0.0,
-        0.0,
-        1.0
-    ],
-    "scale": [
-        0.019999999552965164,
-        0.019999999552965164,
-        0.019999999552965164
     ]
-
 }

--- a/testing/test_plugins/SerializeWorkspace.py
+++ b/testing/test_plugins/SerializeWorkspace.py
@@ -1,0 +1,27 @@
+import os
+import nanome
+from nanome.util import async_callback
+from nanome.api import schemas
+
+# Config
+
+NAME = "Serialize Workspace"
+DESCRIPTION = "Load workspace and serialize as JSON."
+HAS_ADVANCED_OPTIONS = False
+CATEGORY = 'Testing'
+
+# Plugin
+
+
+class SerializeWorkspace(nanome.AsyncPluginInstance):
+    
+    @async_callback
+    async def start(self):
+        ws = await self.request_workspace()
+        ws_schema = schemas.WorkspaceSchema()
+        json_data = ws_schema.dumps(ws)
+        file_path = os.path.join(os.getcwd(), 'serialized_workspace.json')
+        with open(file_path, 'w') as f:
+            f.write(json_data)
+
+nanome.Plugin.setup(NAME, DESCRIPTION, CATEGORY, HAS_ADVANCED_OPTIONS, SerializeWorkspace)

--- a/testing/test_plugins/SerializeWorkspace.py
+++ b/testing/test_plugins/SerializeWorkspace.py
@@ -14,7 +14,7 @@ CATEGORY = 'Testing'
 
 
 class SerializeWorkspace(nanome.AsyncPluginInstance):
-    
+
     @async_callback
     async def start(self):
         ws = await self.request_workspace()
@@ -23,5 +23,6 @@ class SerializeWorkspace(nanome.AsyncPluginInstance):
         file_path = os.path.join(os.getcwd(), 'serialized_workspace.json')
         with open(file_path, 'w') as f:
             f.write(json_data)
+
 
 nanome.Plugin.setup(NAME, DESCRIPTION, CATEGORY, HAS_ADVANCED_OPTIONS, SerializeWorkspace)

--- a/testing/unit/test_schemas.py
+++ b/testing/unit/test_schemas.py
@@ -55,6 +55,67 @@ class StructureSchemaTestCase(unittest.TestCase):
         loaded_mol = next(loaded_comp.molecules)
         self.assertEqual(loaded_mol.conformer_count, 5)
 
+    def test_structure_schema_dump(self):
+        """Make sure StructureSchema can parse the correct structure type."""
+        with open(workspace_json, 'r') as f:
+            workspace_data = json.load(f)
+        workspace = schemas.WorkspaceSchema().load(workspace_data)
+        comp = workspace.complexes[0]
+        mol = next(comp.molecules)
+        chain = next(comp.chains)
+        residue = next(comp.residues)
+        atom = next(comp.atoms)
+        bond = next(comp.bonds)
+        schema = schemas.StructureSchema()
+
+        comp_data = schema.dump(comp)
+        self.assertTrue(isinstance(comp_data, dict))
+
+        mol_data = schema.dump(mol)
+        self.assertTrue(isinstance(mol_data, dict))
+
+        chain_data = schema.dump(chain)
+        self.assertTrue(isinstance(chain_data, dict))
+
+        residue_data = schema.dump(residue)
+        self.assertTrue(isinstance(residue_data, dict))
+
+        bond_data = schema.dump(bond)
+        self.assertTrue(isinstance(bond_data, dict))
+
+        atom_data = schema.dump(atom)
+        self.assertTrue(isinstance(atom_data, dict))
+
+    def test_structure_schema_load(self):
+        """Make sure StructureSchema can parse the correct structure type."""
+        with open(workspace_json, 'r') as f:
+            workspace_data = json.load(f)
+        struct_schema = schemas.StructureSchema()
+
+        comp_data = workspace_data['complexes'][0]
+        comp = struct_schema.load(comp_data)
+        self.assertTrue(isinstance(comp, structure.Complex))
+        
+        mol_data = comp_data['molecules'][0]
+        mol = struct_schema.load(mol_data)
+        self.assertTrue(isinstance(mol, structure.Molecule))
+        
+        chain_data = mol_data['chains'][0]
+        chain = struct_schema.load(chain_data)
+        self.assertTrue(isinstance(chain, structure.Chain))
+        
+        residue_data = chain_data['residues'][0]
+        residue = struct_schema.load(residue_data)
+        self.assertTrue(isinstance(residue, structure.Residue))
+
+        bond_data = residue_data['bonds'][0]
+        bond = struct_schema.load(bond_data)
+        self.assertTrue(isinstance(bond, structure.Bond))
+
+        atom_data = residue_data['atoms'][0]
+        atom = struct_schema.load(atom_data)
+        self.assertTrue(isinstance(atom, structure.Atom))
+
 
 @unittest.skipIf(not reqs_installed, "Marshmallow not installed")
 class UISchemaTestCase(unittest.TestCase):

--- a/testing/unit/test_schemas.py
+++ b/testing/unit/test_schemas.py
@@ -107,15 +107,15 @@ class StructureSchemaTestCase(unittest.TestCase):
         comp_data = workspace_data['complexes'][0]
         comp = struct_schema.load(comp_data)
         self.assertTrue(isinstance(comp, structure.Complex))
-        
+
         mol_data = comp_data['molecules'][0]
         mol = struct_schema.load(mol_data)
         self.assertTrue(isinstance(mol, structure.Molecule))
-        
+
         chain_data = mol_data['chains'][0]
         chain = struct_schema.load(chain_data)
         self.assertTrue(isinstance(chain, structure.Chain))
-        
+
         residue_data = chain_data['residues'][0]
         residue = struct_schema.load(residue_data)
         self.assertTrue(isinstance(residue, structure.Residue))

--- a/testing/unit/test_schemas.py
+++ b/testing/unit/test_schemas.py
@@ -70,21 +70,33 @@ class StructureSchemaTestCase(unittest.TestCase):
 
         comp_data = schema.dump(comp)
         self.assertTrue(isinstance(comp_data, dict))
+        reloaded_comp = schema.load(comp_data)
+        self.assertTrue(isinstance(reloaded_comp, structure.Complex))
 
         mol_data = schema.dump(mol)
         self.assertTrue(isinstance(mol_data, dict))
+        reloaded_mol = schema.load(mol_data)
+        self.assertTrue(isinstance(reloaded_mol, structure.Molecule))
 
         chain_data = schema.dump(chain)
         self.assertTrue(isinstance(chain_data, dict))
+        reloaded_chain = schema.load(chain_data)
+        self.assertTrue(isinstance(reloaded_chain, structure.Chain))
 
         residue_data = schema.dump(residue)
         self.assertTrue(isinstance(residue_data, dict))
+        reloaded_residue = schema.load(residue_data)
+        self.assertTrue(isinstance(reloaded_residue, structure.Residue))
 
         bond_data = schema.dump(bond)
         self.assertTrue(isinstance(bond_data, dict))
+        reloaded_bond = schema.load(bond_data)
+        self.assertTrue(isinstance(reloaded_bond, structure.Bond))
 
         atom_data = schema.dump(atom)
         self.assertTrue(isinstance(atom_data, dict))
+        reloaded_atom = schema.load(atom_data)
+        self.assertTrue(isinstance(reloaded_atom, structure.Atom))
 
     def test_structure_schema_load(self):
         """Make sure StructureSchema can parse the correct structure type."""


### PR DESCRIPTION
- Use StructureSchema to dynamically determine which type of structure to create.
- Add tests to validate StructureSchema
- Add SerializeWorkspace test plugin to generate workspace schemas