### PR TITLE
Fix SDF save bug

### DIFF
--- a/nanome/_internal/_structure/_complex.py
+++ b/nanome/_internal/_structure/_complex.py
@@ -111,8 +111,3 @@ class _Complex(_Base):
     def _convert_to_frames(self, old_to_new_atoms=None):
         result = _helpers._conformer_helper.convert_to_frames(self, old_to_new_atoms)
         return result
-
-    def __copy_received_complex(self, new_complex):
-        if new_complex != None:
-            new_complex._shallow_copy(self)
-            self._molecules = new_complex._molecules

--- a/nanome/_internal/_structure/_io/_sdf/save.py
+++ b/nanome/_internal/_structure/_io/_sdf/save.py
@@ -60,6 +60,8 @@ def to_file(path, complex, options=None):
             if (options.write_all_bonds) or (options.write_het_bonds and chain._name[0] == 'H'):
                 for residue in chain._residues:
                     for bond in residue._bonds:
+                        if not bond.atom1 or not bond.atom2:
+                            continue
                         if bond.atom1._unique_identifier in serial_by_atom_unique and bond.atom2._unique_identifier in serial_by_atom_unique:
                             saved_bond = Results.SavedBond()
                             saved_bond.serial_atom1 = serial_by_atom_unique[bond.atom1._unique_identifier]

--- a/nanome/_internal/_structure/_io/_sdf/save.py
+++ b/nanome/_internal/_structure/_io/_sdf/save.py
@@ -1,6 +1,5 @@
 import nanome
-from nanome._internal._structure import _Complex, _Molecule, _Chain, _Residue, _Atom, _Bond
-from nanome.util import Logs
+from nanome._internal._structure import _Complex
 
 Options = nanome.util.complex_save_options.SDFSaveOptions
 

--- a/nanome/_internal/_structure/_io/_sdf/save.py
+++ b/nanome/_internal/_structure/_io/_sdf/save.py
@@ -10,13 +10,13 @@ class Results(object):
         self.saved_bonds = []
 
     class SavedAtom(object):
-        def __init(self):
+        def __init__(self):
             self.serial = 0
             self.atom = None
             self.model_number = 0
 
     class SavedBond(object):
-        def __init(self):
+        def __init__(self):
             self.serial_atom1 = 0
             self.serial_atom2 = 0
             self.bond = None


### PR DESCRIPTION
* Continue bond loop if atoms not found

* Also delete unused double underscore function

Fixes Chemical Properties error in Graylog message graylog_0/7f205280-2231-11ed-9c53-0242ac120002