### PR TITLE
Fix SDF parsing associated data

### DIFF
--- a/nanome/_internal/_structure/_io/_sdf/parse.py
+++ b/nanome/_internal/_structure/_io/_sdf/parse.py
@@ -111,7 +111,7 @@ def parse_model(lines):
                                     model.bonds.append(bond)
                 if line[0] == '>':
                     regexpression = re.compile(r">\s+<(.+?)>")
-                    title = re.match(regexpression, line).group(0)
+                    title = re.match(regexpression, line).group(1)
                     line_counter = line_counter + 1
                     data = ""
                     # read line until you see another comment or the end of the molecule


### PR DESCRIPTION
SDF associated data is stored in the format:
```
> <Property>
Value
```

There was a bug in the SDF parser regex usage where it was grabbing the full `> <Property>` as the property name instead of `Property`. This PR fixes that.