### PR TITLE
add back chmod for dssp, wrap in try/except

### DIFF
--- a/nanome/_internal/process/dssp.py
+++ b/nanome/_internal/process/dssp.py
@@ -16,6 +16,10 @@ logger = logging.getLogger(__name__)
 
 if sys.platform.startswith("linux"):
     DSSP_PATH = os.path.join(os.path.dirname(__file__), 'external', 'dssp', 'dssp-linux')
+    try:
+        os.chmod(DSSP_PATH, 0o777)
+    except PermissionError:
+        logger.warning("Could not set DSSP as executable")
 elif sys.platform.startswith("win"):
     DSSP_PATH = os.path.join(os.path.dirname(__file__), 'external', 'dssp', 'dssp-3.0.0-win32.exe')
 else:

--- a/nanome/util/config.py
+++ b/nanome/util/config.py
@@ -129,12 +129,12 @@ def set(key, value):
 
 def _get_config_dict():
     config_path = _setup_file()
-    with open(config_path, "r") as f:
-        try:
+    if config_path:
+        with open(config_path, "r") as f:
             config_dict = json.load(f)
-        except json.decoder.JSONDecodeError:
-            logger.warning("{} setup failed".format(config_path))
-            config_dict = {}
+    else:
+        logger.warning("Could not write config file, please check permissions.")
+        config_dict = {}
     serialized_dict = _serialize_dict_with_parser(config_dict)
     return serialized_dict
 


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/app/run.py", line 1, in <module>
    from plugin import StructurePrep
  File "/app/plugin/StructurePrep.py", line 1, in <module>
    import nanome
  File "/opt/conda/lib/python3.9/site-packages/nanome/__init__.py", line 3, in <module>
    from .api import *
  File "/opt/conda/lib/python3.9/site-packages/nanome/api/__init__.py", line 2, in <module>
    from .room import Room
  File "/opt/conda/lib/python3.9/site-packages/nanome/api/room.py", line 2, in <module>
    from nanome._internal._room import _Room
  File "/opt/conda/lib/python3.9/site-packages/nanome/_internal/__init__.py", line 12, in <module>
    from ._plugin_instance import _PluginInstance  # noqa F401
  File "/opt/conda/lib/python3.9/site-packages/nanome/_internal/_plugin_instance.py", line 4, in <module>
    from nanome._internal._process import ProcessManagerInstance
  File "/opt/conda/lib/python3.9/site-packages/nanome/_internal/_process/__init__.py", line 7, in <module>
    from ._dssp import _Dssp
  File "/opt/conda/lib/python3.9/site-packages/nanome/_internal/_process/_dssp.py", line 19, in <module>
    os.chmod(DSSP_PATH, 0o777)
PermissionError: [Errno 1] Operation not permitted: '/opt/conda/lib/python3.9/site-packages/nanome/_internal/_process/_external/_dssp/dssp-linux'

```