### PR TITLE
Schema bond fix

### DIFF
--- a/nanome/api/schemas/structure_schemas.py
+++ b/nanome/api/schemas/structure_schemas.py
@@ -50,6 +50,7 @@ class AtomSchema(Schema):
     in_conformer = fields.List(fields.Boolean())
     het_surfaced = fields.Boolean()
     display_mode = fields.Integer()
+    unique_identifier = fields.Integer(attribute='_unique_identifier')
 
     @post_load
     def make_atom(self, data, **kwargs):
@@ -60,8 +61,8 @@ class AtomSchema(Schema):
 
 class BondSchema(Schema):
     index = fields.Integer(default=-1)
-    atom1 = fields.Nested(AtomSchema(only=('index',)))
-    atom2 = fields.Nested(AtomSchema(only=('index',)))
+    atom1 = fields.Nested(AtomSchema())
+    atom2 = fields.Nested(AtomSchema())
     kind = EnumField(enum=enums.Kind)
     in_conformer = fields.List(fields.Boolean())
     kinds = fields.List(EnumField(enum=enums.Kind))

--- a/testing/test_plugins/SchemaBondTest.py
+++ b/testing/test_plugins/SchemaBondTest.py
@@ -9,7 +9,8 @@ CATEGORY = "testing"
 HAS_ADVANCED_OPTIONS = False
 
 
-class SchemaTest(nanome.AsyncPluginInstance):
+class SchemaBondTest(nanome.AsyncPluginInstance):
+    """Validate that bonds aren't lost during schema serialization/deserialization."""
 
     @async_callback
     async def start(self):

--- a/testing/test_plugins/SchemaBondTest.py
+++ b/testing/test_plugins/SchemaBondTest.py
@@ -21,11 +21,14 @@ class SchemaBondTest(nanome.AsyncPluginInstance):
         index = shallow[0].index
 
         [comp] = await self.request_complexes([index])
+        atom_count = len(list(comp.atoms))
         bond_count = len(list(comp.bonds))
         comp_data = json.dumps(schemas.ComplexSchema().dump(comp))
         new_comp = schemas.ComplexSchema().loads(comp_data)
+        new_comp_atom_count = len(list(new_comp.atoms))
         new_comp_bond_count = len(list(new_comp.bonds))
         assert bond_count == new_comp_bond_count
+        assert atom_count == new_comp_atom_count
 
         for res in new_comp.residues:
             res.ribbon_color = Color.Blue()
@@ -33,8 +36,10 @@ class SchemaBondTest(nanome.AsyncPluginInstance):
 
         [updated_comp] = await self.request_complexes([index])
         updated_bond_count = len(list(updated_comp.bonds))
+        updated_atom_count = len(list(updated_comp.atoms))
         # this assertion fails
         assert bond_count == updated_bond_count
+        assert atom_count == updated_atom_count
         Logs.message('done')
 
 

--- a/testing/test_plugins/SchemaBondTest.py
+++ b/testing/test_plugins/SchemaBondTest.py
@@ -11,11 +11,11 @@ HAS_ADVANCED_OPTIONS = False
 
 class SchemaTest(nanome.AsyncPluginInstance):
 
-    def start(self):
-        self.on_run()
-
     @async_callback
-    async def on_run(self):
+    async def start(self):
+        await self.run_test()
+
+    async def run_test(self):
         shallow = await self.request_complex_list()
         index = shallow[0].index
 

--- a/testing/test_plugins/SchemaBondTest.py
+++ b/testing/test_plugins/SchemaBondTest.py
@@ -38,4 +38,4 @@ class SchemaBondTest(nanome.AsyncPluginInstance):
         Logs.message('done')
 
 
-nanome.Plugin.setup(NAME, DESCRIPTION, CATEGORY, False, SchemaTest)
+nanome.Plugin.setup(NAME, DESCRIPTION, CATEGORY, False, SchemaBondTest)


### PR DESCRIPTION
Fixes issue where bonds were lost after serializing/deserializing complex

Issues:
* Atom was missing unique_identifier field.

* atom1 and atom2 in the BondSchema was only saving index, in an effort to reduce payload size. However, that minimal atom was being saved as the primary atom data for the payload here.
https://github.com/nanome-ai/nanome-lib/blob/master/nanome/api/structure/serializers.py#L189
So when the payload was serialized, all the important data was missing.